### PR TITLE
Sky fibre assignment fix, FW code reformatted to PEP8 line length standard

### DIFF
--- a/funnelweb_generate_tiling.py
+++ b/funnelweb_generate_tiling.py
@@ -1,9 +1,10 @@
 """Script for generating the tiling for FunnelWeb
 
 Notes about this script:
-- To change the settings used for tiling generation, modify funnelweb_tiling_settings.py
-- ipython "%run -i funnelweb_generate_tiling" to avoid having to read in target list twice
-  for repeated runs
+- To change the settings used for tiling generation, modify 
+  funnelweb_tiling_settings.py
+- ipython "%run -i funnelweb_generate_tiling" to avoid having to read in target 
+  list twice for repeated runs
 - Test speed with:
     kernprof -l funnelweb_generate_tiling.py
     python -m line_profiler script_to_profile.py.lprof
@@ -28,12 +29,13 @@ import funnelweb_tiling_settings as fwts
 from shutil import copyfile
 from collections import OrderedDict
 
-#-----------------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # Helper Functions
-#-----------------------------------------------------------------------------------------
-def load_targets(catalogue, ra_min, ra_max, dec_min, dec_max, gal_lat_limit, tab_type,
-                 priorities=None, priority_normal=2, use_colour_cut=False, 
-                 standard_frac=0.1, colour_index_cut=0.5):
+#------------------------------------------------------------------------------
+def load_targets(catalogue, ra_min, ra_max, dec_min, dec_max, gal_lat_limit,
+                 tab_type, priorities=None, priority_normal=2, 
+                 use_colour_cut=False, standard_frac=0.1, 
+                 colour_index_cut=0.5):
     """Function to import the input catalogue and make any required cuts.
     
     Parameters
@@ -53,23 +55,27 @@ def load_targets(catalogue, ra_min, ra_max, dec_min, dec_max, gal_lat_limit, tab
     tab_type: string
         The format of the input catalogue, currently either 'gaia' or 'fw'.
     priorities: string or None
-        Either a string filepath to a .fits file with ID-priority pairs, or None if every
-        star should be assigned the same initial priority of priority_normal.
+        Either a string filepath to a .fits file with ID-priority pairs, or 
+        None if every star should be assigned the same initial priority of 
+        priority_normal.
     priority_normal: int
-        The normal priority to assign to all stars if we don't have the ID-priority pairs.
+        The normal priority to assign to all stars if we don't have the 
+        ID-priority pairs.
     use_colour_cut: boolean
-        Boolean indicating whether standard stars are selected based on a colour cut, or 
-        whether to simply use a fraction of the total stars as standards.
+        Boolean indicating whether standard stars are selected based on a 
+        colour cut, or whether to simply use a fraction of the total stars as 
+        standards.
     standard_frac: float
-        Fraction between 0.0 and 1.0 representing the fraction of stars to be considered
-        standards if not using a colour cut.
+        Fraction between 0.0 and 1.0 representing the fraction of stars to be 
+        considered standards if not using a colour cut.
     colour_index_cut: float
-        The colour index cut below which (i.e. hotter than which) standards are selected. 
+        The colour index cut below which (i.e. hotter than which) standards are
+        selected. 
               
     Returns
     -------
     all_targets: list of TaipanTarget objects
-        A list containing all candidate targets within the constraints given.            
+        A list containing all candidate targets within the constraints given.
     """
     # Load in the entire input catalogue
     start = time.time()
@@ -82,32 +88,35 @@ def load_targets(catalogue, ra_min, ra_max, dec_min, dec_max, gal_lat_limit, tab
         start = time.time()
         priorities = import_target_priorities(priorities)
         delta = time.time() - start
-        print ("Loaded target priorities in %d:%02.1f") % (delta/60, delta % 60.)
+        print ("Loaded target priorities in %d:%02.1f") % (delta/60, 
+                                                           delta % 60.)
     
     start = time.time()
     all_targets = []
     
-    # Create TaipanTarget objects for those targets meeting RA/DEC/b requirements
+    # Create TaipanTarget objects for targets meeting RA/DEC/b requirements
     if tab_type == 'gaia':
         for star in tabdata:
             # Only consider targets which satisfy RA/DEC/b restrictions
-            if (ra_min < star["ra"] < ra_max) and (dec_min < star["dec"] < dec_max) \
-                and (np.abs(star['b']) > gal_lat_limit):
-               # Target is acceptable, create with parameters necessary for tiling
-                target = tp.FWTarget(int(star["source_id"]), star["ra"], star["dec"], 
-                                         priority=get_target_priority(star["source_id"], 
-                                                                      priorities, 
-                                                                      priority_normal), 
-                                         mag=star["phot_g_mean_mag"], difficulty=1)
+            if (ra_min < star["ra"] < ra_max) and (dec_min < star["dec"] 
+                < dec_max) and (np.abs(star['b']) > gal_lat_limit):
+                # Target is acceptable, create with tiling parameters
+                priority = get_target_priority(star["source_id"], priorities, 
+                                               priority_normal)
+                                               
+                target = tp.FWTarget(int(star["source_id"]), star["ra"],
+                                     star["dec"], priority=priority, 
+                                     mag=star["phot_g_mean_mag"], difficulty=1)
                 
-                # Now check whether the star is a standard or not. We cannot (currently)
-                # do this in a list comprehension as assigning anything to non-standard
-                # stars (i.e. False or None) results in bugs within the tiling/taipan 
-                # code, the cause of which is unclear and fixing it is not currently a
-                # priority. We have to do this here if we want to access other magnitudes
-                # for making cuts based on colour index (i.e. using 2MASS J & K), numbers
-                # which are not required elsewhere in the tiling code so it is needlessly
-                # complex to assign them as class parameters.
+                # Now check whether the star is a standard or not. We cannot 
+                # (currently) do this in a list comprehension as assigning 
+                # anything to non-standard stars (i.e. False or None) results 
+                # in bugs within the tiling/taipan code, the cause of which is
+                # unclear and fixing it is not currently a priority. We have to
+                # do this here if we want to access other magnitudes for making
+                # cuts based on colour index (i.e. using 2MASS J & K), numbers
+                # which are not required elsewhere in the tiling code so it is
+                # needlessly complex to assign them as class parameters.
                 if is_standard(star, use_colour_cut, standard_frac, tab_type):
                     target.standard = True           
             
@@ -117,18 +126,20 @@ def load_targets(catalogue, ra_min, ra_max, dec_min, dec_max, gal_lat_limit, tab
     elif tab_type == "fw":
         for star in tabdata:
             # Only consider targets which satisfy RA/DEC/b restrictions
-            if (ra_min < star["RA_ep2015"] < ra_max) \
-                and (dec_min < star["Dec_ep2015"] < dec_max) \
-                and (np.abs(star['b']) > gal_lat_limit) and star["Gaia_G_mag"] <= 30:
-               # Target is acceptable, create with parameters necessary for tiling
+            if ((ra_min < star["RA_ep2015"] < ra_max)
+                and (dec_min < star["Dec_ep2015"] < dec_max)
+                and (np.abs(star['b']) > gal_lat_limit) 
+                and star["Gaia_G_mag"] <= 30):
+                # Target is acceptable, create with tiling parameters
+                priority = get_target_priority(star["Gaia_ID"], priorities, 
+                                               priority_normal)
+                                               
                 target = tp.FWTarget(int(star["Gaia_ID"]), star["RA_ep2015"], 
-                                         star["Dec_ep2015"], 
-                                         priority=get_target_priority(star["Gaia_ID"], 
-                                                                      priorities, 
-                                                                      priority_normal), 
-                                         mag=star["Gaia_G_mag"], difficulty=1)
+                                     star["Dec_ep2015"], priority=priority, 
+                                     mag=star["Gaia_G_mag"], difficulty=1)
                 
-                # Check if star is a standard (same reasoning as above for tab_type=gaia)
+                # Check if star is a standard (same reasoning as above for 
+                # tab_type=gaia)
                 if is_standard(star, use_colour_cut, standard_frac, tab_type):
                     target.standard = True           
             
@@ -145,34 +156,37 @@ def load_targets(catalogue, ra_min, ra_max, dec_min, dec_max, gal_lat_limit, tab
     start = time.time()
     burn = [t.compute_usposn() for t in all_targets]
     delta = time.time() - start
-    print "Calculated target US positions in %d:%02.1f" % (delta/60, delta % 60.)
+    print "Calculated target US positions in %d:%02.1f" % (delta/60, 
+                                                           delta % 60.)
     
     return all_targets
     
 
 def is_standard(star, use_colour_cut=False, standard_frac=0.1, tabtype="fw", 
                 colour_index_cut=0.5):
-    """Prototype function to determine whether a star can be considered a standard or not.
+    """Function to determine whether a star can be considered a standard.
     
     Parameters
     ----------
     star: list
         Row of the input catalogue corresponding the the star to be checked.
     use_colour_cut: boolean
-        Boolean indicating whether standard stars are selected based on a colour cut, or 
-        whether to simply use a fraction of the total stars as standards.
+        Boolean indicating whether standard stars are selected based on a 
+        colour cut, or whether to simply use a fraction of the total stars as 
+        standards.
     standard_frac: float
-        Fraction between 0.0 and 1.0 representing the fraction of stars to be considered
-        standards if not using a colour cut.
+        Fraction between 0.0 and 1.0 representing the fraction of stars to be 
+        considered standards if not using a colour cut.
     tab_type: string
         The format of the input catalogue, currently either 'gaia' or 'fw'.
     colour_index_cut: float
-        The colour index cut below which (i.e. hotter than which) standards are selected.
+        The colour index cut below which (i.e. hotter than which) standards are
+        selected.
                 
     Returns
     -------
     is_standard: boolean
-        Boolean value indicating whether the star can be considered a standard or not.
+        Boolean value indicating whether the star can be considered a standard.
     """
     if use_colour_cut:
         # Calculate the colour indices
@@ -187,11 +201,12 @@ def is_standard(star, use_colour_cut=False, standard_frac=0.1, tabtype="fw",
     else:
         # Not using a colour cut - assign standards based on a simple fraction.
         # TODO: Update to this to allow for stars without G mags
-        if tabtype == "fw" and (int(star["Gaia_G_mag"]*100) % int(1/standard_frac)) == 0:
+        if (tabtype == "fw"
+            and (int(star["Gaia_G_mag"]*100) % int(1/standard_frac)) == 0):
             is_standard = True
             
-        elif tabtype == "gaia" \
-            and (int(star["phot_g_mean_mag"]*100) % int(1/standard_frac)) == 0:
+        elif (tabtype == "gaia"
+            and (int(star["phot_g_mean_mag"]*100) % int(1/standard_frac)) ==0):
             is_standard = True
             
         else:
@@ -201,8 +216,9 @@ def is_standard(star, use_colour_cut=False, standard_frac=0.1, tabtype="fw",
 
 
 def get_target_priority(target_id, target_priorities=None, normal_priority=2):
-    """Attempts to lookup the provided target ID in the master list of target priorities,
-    returning the priority if found. Otherwise, returns the accepted "normal" priority.
+    """Attempts to lookup the provided target ID in the master list of target 
+    priorities, returning the priority if found. Otherwise, returns the 
+    accepted "normal" priority.
     
     Parameters
     ----------
@@ -234,8 +250,8 @@ def get_target_priority(target_id, target_priorities=None, normal_priority=2):
     
     
 def import_target_priorities(priorities_fits_file):
-    """Imports the target priorities and converts to a dictionary format to optimise 
-    priority lookup when constructing targets.
+    """Imports the target priorities and converts to a dictionary format to 
+    optimise priority lookup when constructing targets.
     
     Parameters
     ----------
@@ -250,7 +266,7 @@ def import_target_priorities(priorities_fits_file):
     # Load in the input priority list
     target_priorities_table = Table.read(priorities_fits_file)
     
-    # Initialise the dictionary that will be used to store the ID-priority pairs
+    # Initialise dictionary that will be used to store the ID-priority pairs
     # Quicker to construct dictionary from keys (i.e. pre-size), then populate
     ids = set(target_priorities_table["Gaia_ID"])
     target_priorities = dict.fromkeys(ids)
@@ -261,8 +277,10 @@ def import_target_priorities(priorities_fits_file):
     return target_priorities
 
 
-def load_sky_targets(dark_sky_fits, ra_min, ra_max, dec_min, dec_max, priority_normal=2):
-    """Function to import the input sky catalogue as FWTargets and make any required cuts.
+def load_sky_targets(dark_sky_fits, ra_min, ra_max, dec_min, dec_max, 
+                     priority_normal=2):
+    """Function to import the input sky catalogue as FWTargets and make any 
+    required cuts.
     
     Parameters
     ----------
@@ -282,7 +300,7 @@ def load_sky_targets(dark_sky_fits, ra_min, ra_max, dec_min, dec_max, priority_n
     Returns
     -------
     sky_targets: list of FWTarget objects
-        A list containing all candidate targets within the constraints given.            
+        A list containing all candidate targets within the constraints given.
     """
     # Import the dark sky catalogue
     start = time.time()
@@ -296,7 +314,8 @@ def load_sky_targets(dark_sky_fits, ra_min, ra_max, dec_min, dec_max, priority_n
                    priority=priority_normal, mag=25, difficulty=1, 
                    science=False, standard=False, guide=False, sky=True) 
                    for sky in sky_table[1:] 
-                   if (ra_min < sky["ra"] < ra_max) and (dec_min < sky["dec"] < dec_max)]
+                   if (ra_min < sky["ra"] < ra_max) 
+                   and (dec_min < sky["dec"] < dec_max)]
     
     
     delta = time.time() - start
@@ -313,15 +332,15 @@ def load_sky_targets(dark_sky_fits, ra_min, ra_max, dec_min, dec_max, priority_n
     
     
 def update_taipan_quadrants():
-    """Function to recompute the number and placement of quadrants that split up a field
-    and define sky fibre locations.
+    """Function to recompute the number and placement of quadrants that split
+    up a field and define sky fibre locations.
     """
     if len(tp.QUAD_PER_RADII) != len(tp.QUAD_RADII)-1:
         raise ValueError('QUAD_PER_RADII must have one less element than '
                      'QUAD_RADII')
     if sum(tp.QUAD_PER_RADII) != tp.SKY_PER_TILE:
-        raise UserWarning('The number of defined tile quandrants does not match '
-                          'SKY_PER_TILE. These are meant to be the same!')
+        raise UserWarning('The number of defined tile quandrants does not '
+                          'match KY_PER_TILE. These are meant to be the same!')
 
     tp.FIBRES_PER_QUAD = []
     for i in range(len(tp.QUAD_RADII))[:-1]:
@@ -330,12 +349,13 @@ def update_taipan_quadrants():
             tp.FIBRES_PER_QUAD.append(
                 [k for k in tp.BUGPOS_OFFSET.keys() if
                  k not in tp.FIBRES_GUIDE and
-                 tp.QUAD_RADII[i+1] <= tp.BUGPOS_OFFSET[k][0] < tp.QUAD_RADII[i] and
-                 j*theta <= tp.BUGPOS_OFFSET[k][1] < (j+1)*theta])
+                 tp.QUAD_RADII[i+1] <= tp.BUGPOS_OFFSET[k][0] 
+                 < tp.QUAD_RADII[i] 
+                 and j*theta <= tp.BUGPOS_OFFSET[k][1] < (j+1)*theta])
                        
-#-----------------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # Setup
-#-----------------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # Reload fwts for repeated runs
 reload(fwts)
 
@@ -349,10 +369,11 @@ tp.GUIDES_PER_TILE_MIN = fwts.script_settings["GUIDES_PER_TILE_MIN"]
 # For guides and sky fibres: enough to fit a linear trend and get a chi-squared 
 # uncertainty distribution with 4 degrees of freedom, with 1 bad fibre.
 
-# To update the number of sky fibres, you need to update the following four parameters
-# and recompute the how the tile area itself is segmented into "quadrants". Sky fibres are
-# allocated in increments of the number of quadrants, so this needs to be recomputed in 
-# order to properly update the number of sky fibres used.
+# To update the number of sky fibres, you need to update the following four 
+# parameters and recompute the how the tile area itself is segmented into 
+# "quadrants". Sky fibres are allocated in increments of the number of 
+# quadrants, so this needs to be recomputed in order to properly update the 
+# number of sky fibres used.
 tp.SKY_PER_TILE = fwts.script_settings["SKY_PER_TILE"]
 tp.SKY_PER_TILE_MIN = fwts.script_settings["SKY_PER_TILE_MIN"]
 tp.QUAD_RADII = fwts.script_settings["QUAD_RADII"]
@@ -370,16 +391,16 @@ copyfile(settings_file, temp_settings_file)
 # Prompt user for the description or motivation of the run
 run_description = raw_input("Description/motivation for tiling run: ")
 
-# No description given, assign one based on on-sky area, machine, and number of cores
+# No description given, assign one based on on-sky area, machine, and # cores
 if run_description == "": 
     ra_range = fwts.tiler_input["ra_max"] - fwts.tiler_input["ra_min"]
     dec_range = fwts.tiler_input["dec_max"] - fwts.tiler_input["dec_min"]
     run_description = "%s, %ix%i, backend=%s, n_cores=%i" % (platform.node(),
-                                                             ra_range, dec_range, 
-                                                             fwts.tiler_input["backend"],
-                                                             fwts.tiler_input["n_cores"])
+                                                ra_range, dec_range, 
+                                                fwts.tiler_input["backend"],
+                                                fwts.tiler_input["n_cores"])
 
-# Begin logging, ensuring that we create a new log file handler unique to this run
+# Begin logging, ensuring creation of a new log file handler unique to this run
 log_file = "funnelweb_generate_tiling.log"
 temp_log_file = "results/temp_" + temp_timestamp + log_file
 log_file_handler = logging.FileHandler(temp_log_file, "a")
@@ -388,22 +409,26 @@ logging.getLogger().handlers = [log_file_handler]
 # Initialise the tiler
 fwtiler = FWTiler(**fwts.tiler_input)
 
-#-----------------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # Importing & Generating Science, Standard, and Guide Targets
-#-----------------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 try:
     # Check to see if we already have the targets imported, thus saving time
     if all_targets:
-        print "Previously loaded catalogue will be used, on-sky area: %ix%i" % (ra_range, 
-                                                                                dec_range)
+        print "Previously loaded catalogue will be used,",
+        print "on-sky area: %ix%i" % (ra_range, dec_range)
+        
 except NameError:
-    # Not already imported, so import targets and generate TaipanTarget objects for each
+    # Not already imported, import targets and generate TaipanTarget objects
     cat = fwts.script_settings["input_catalogue"].split("/")[-1]
-    print "Importing catalogue '%s' for on-sky area: %ix%i" % (cat, ra_range, dec_range)
+    print "Importing catalogue '%s' for on-sky area: %ix%i" % (cat, ra_range, 
+                                                               dec_range)
 
     all_targets = load_targets(fwts.script_settings["input_catalogue"],
-                               fwts.tiler_input["ra_min"], fwts.tiler_input["ra_max"], 
-                               fwts.tiler_input["dec_min"], fwts.tiler_input["dec_max"],
+                               fwts.tiler_input["ra_min"], 
+                               fwts.tiler_input["ra_max"], 
+                               fwts.tiler_input["dec_min"], 
+                               fwts.tiler_input["dec_max"],
                                fwts.script_settings["gal_lat_limit"],
                                fwts.script_settings["tab_type"],
                                fwts.script_settings["input_priorities"], 
@@ -413,88 +438,96 @@ except NameError:
                                fwts.script_settings["colour_index_cut"])
     
     all_sky = load_sky_targets(fwts.script_settings["sky_catalogue"],
-                               fwts.tiler_input["ra_min"], fwts.tiler_input["ra_max"], 
-                               fwts.tiler_input["dec_min"], fwts.tiler_input["dec_max"],
+                               fwts.tiler_input["ra_min"], 
+                               fwts.tiler_input["ra_max"], 
+                               fwts.tiler_input["dec_min"], 
+                               fwts.tiler_input["dec_max"],
                                fwts.tiler_input["priority_normal"])
                                
-# Make a copy of all_targets list for use in assigning fibres. For speed, this is a set
+# Make a copy of all_targets list for use in assigning fibres. For speed, this
+# is a set
 candidate_targets = set(all_targets)
 
 sky_targets = all_sky[:]
 
-# Now create separate lists for standard and guide targets. These will be drawn from the 
-# candidate_targets set (i.e. using references to the same objects, rather than copies).
+# Now create separate lists for standard and guide targets. These will be drawn
+# from the candidate_targets set (i.e. using references to the same objects, 
+# rather than copies).
 
 # Standard stars are those that we previously flagged the 'standard' flag for
 standard_targets = [t for t in candidate_targets if t.standard==True]
 
-# Guide targets are drawn from a separate magnitude range and will have their flags set
-# later during the tiling itself
+# Guide targets are drawn from a separate magnitude range and will have their 
+# flags set later during the tiling itself
 guide_targets = set([t for t in candidate_targets 
                      if fwts.script_settings["guide_range"][0] < t.mag 
                      < fwts.script_settings["guide_range"][1]])          
                                                   
-#-----------------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # Generate Tiling
-#-----------------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 print "Commencing tiling with %i core/s using" % (fwts.tiler_input["n_cores"]),
-print "%i science, %i standard, %i guide, & %i sky targets\n" % (len(candidate_targets), 
-                                                                 len(standard_targets), 
-                                                                 len(guide_targets),
-                                                                 len(sky_targets))
+print "%i science," % len(candidate_targets), 
+print "%i standard" % len(standard_targets),
+print "%i guide, & %i sky targets\n" % (len(guide_targets), len(sky_targets))
+                                                                 
 start = datetime.datetime.now()
-tiling, completeness, remaining_targets = fwtiler.generate_tiling(candidate_targets, 
-                                                                  standard_targets, 
-                                                                  guide_targets, 
-                                                                  sky_targets)
+tiling, completeness, leftover_fwt = fwtiler.generate_tiling(candidate_targets, 
+                                                             standard_targets, 
+                                                             guide_targets, 
+                                                             sky_targets)
 end = datetime.datetime.now()
 
-#-----------------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # Analysis
-#-----------------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 time_to_complete = (end - start).total_seconds()
 non_standard_targets_per_tile = [t.count_assigned_targets_science(
-                                 include_science_standards=False) for t in tiling]
+                                 include_science_standards=False) 
+                                 for t in tiling]
 targets_per_tile = [t.count_assigned_targets_science() for t in tiling]
 standards_per_tile = [t.count_assigned_targets_standard() for t in tiling]
 guides_per_tile = [t.count_assigned_targets_guide() for t in tiling]
 sky_per_tile = [t.count_assigned_targets_sky() for t in tiling]
 
-print 'TILING STATS'
-print '------------'
-print 'FW tiling complete using %i core/s in %d:%2.1f' % (fwts.tiler_input["n_cores"],
-        int(np.floor(time_to_complete/60.)), time_to_complete % 60.)
-print '%d targets required %d tiles' % (len(all_targets), len(tiling), )
-print 'Tiling completeness = %4.4f, %i targets remaining' % (completeness, 
-        len(remaining_targets))
-print 'Average %3.1f targets per tile' % np.average(targets_per_tile)
-print '(min %d, max %d, median %d, std %2.1f)' % (min(targets_per_tile),
-    max(targets_per_tile), np.median(targets_per_tile), 
-    np.std(targets_per_tile))
+print "TILING STATS \n------------"
+print "FW tiling complete using %i core/s" % fwts.tiler_input["n_cores"],
+print "in %d:%2.1f" % (int(np.floor(time_to_complete/60.)), 
+                       time_to_complete % 60.)
+print "%d targets required %d tiles" % (len(all_targets), len(tiling), )
+print "Tiling completeness = %4.4f, %i targets remaining" % (completeness, 
+                                                             len(leftover_fwt))
+print "Average %3.1f targets per tile" % np.average(targets_per_tile)
+print "(min %d, max %d, median %d, std %2.1f)" % (min(targets_per_tile),
+                                                  max(targets_per_tile), 
+                                                  np.median(targets_per_tile), 
+                                                  np.std(targets_per_tile))
 print "%i total targets, %i unique targets, %i duplicate targets" % \
     fwtl.count_unique_science_targets(tiling)
     
-#-----------------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # Saving Tiling Outputs
-#-----------------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # Use time stamp as run ID
 date_time = time.strftime("%y%d%m_%H%M_%S_")
 
 # Document the settings and results of the tiling run
-# Dictionary used to easily load results/settings of past runs, OrderedDict so txt has 
-# same format for every run (i.e. the keys are in the order added)
+# Dictionary used to easily load results/settings of past runs, OrderedDict so 
+# txt has same format for every run (i.e. the keys are in the order added)
 run_settings = OrderedDict([("run_id", date_time[:-1]),
                             ("description", run_description),
                             ("mins_to_complete", time_to_complete/60.),
                             ("num_targets", len(all_targets)),
                             ("num_tiles", len(tiling)),
-                            ("avg_targets_per_tile", np.average(targets_per_tile)),
+                            ("avg_targets_per_tile", 
+                             np.average(targets_per_tile)),
                             ("min_targets_per_tile", min(targets_per_tile)),
                             ("max_targets_per_tile", max(targets_per_tile)),
-                            ("median_targets_per_tile", np.median(targets_per_tile)),
+                            ("median_targets_per_tile", 
+                             np.median(targets_per_tile)),
                             ("std_targets_per_tile", np.std(targets_per_tile)),
                             ("tiling_completeness", completeness),
-                            ("remaining_targets", len(remaining_targets)),
+                            ("remaining_targets", len(leftover_fwt)),
                             ("non_standard_targets_per_tile", 
                              non_standard_targets_per_tile),
                             ("targets_per_tile", targets_per_tile),
@@ -509,7 +542,7 @@ run_settings.update(fwts.script_settings)
 # Use pickle to save outputs of tiling in a binary format
 name = "results/" + date_time + "fw_tiling.pkl"
 output = open(name, "wb")
-cPickle.dump( (tiling, remaining_targets, run_settings), output, -1)
+cPickle.dump( (tiling, leftover_fwt, run_settings), output, -1)
 output.close()
 
 # Timestamp the copy of the settings and log files from earlier
@@ -521,8 +554,9 @@ os.rename(temp_log_file, final_log_file)
 
 print "Output files saved as results/%s*" % date_time
                 
-#-----------------------------------------------------------------------------------------
+#------------------------------------------------------------------------------
 # Plotting
-#-----------------------------------------------------------------------------------------
-# Create a pdf summary of the tiling run, with histograms broken up by magnitude range
+#------------------------------------------------------------------------------
+# Create a pdf summary of the tiling run, with histograms broken up by
+# magnitude range
 fwplt.plot_tiling(tiling, run_settings)

--- a/funnelweb_generate_tiling.py
+++ b/funnelweb_generate_tiling.py
@@ -295,7 +295,7 @@ def load_sky_targets(dark_sky_fits, ra_min, ra_max, dec_min, dec_max, priority_n
     sky_targets = [tp.FWTarget(-1*int(sky["pkey_id"]), sky["ra"], sky["dec"], 
                    priority=priority_normal, mag=25, difficulty=1, 
                    science=False, standard=False, guide=False, sky=True) 
-                   for sky in sky_table 
+                   for sky in sky_table[1:] 
                    if (ra_min < sky["ra"] < ra_max) and (dec_min < sky["dec"] < dec_max)]
     
     

--- a/funnelweb_generate_tiling.py
+++ b/funnelweb_generate_tiling.py
@@ -530,7 +530,7 @@ run_settings = OrderedDict([("run_id", date_time[:-1]),
                              np.median(targets_per_tile)),
                             ("std_targets_per_tile", np.std(targets_per_tile)),
                             ("tiling_completeness", completeness),
-                            ("remaining_targets", len(leftover_fwt)),
+                            #("remaining_targets", len(leftover_fwt)),
                             ("non_standard_targets_per_tile", 
                              non_standard_targets_per_tile),
                             ("targets_per_tile", targets_per_tile),
@@ -545,7 +545,7 @@ run_settings.update(fwts.script_settings)
 # Use pickle to save outputs of tiling in a binary format
 name = "results/" + date_time + "fw_tiling.pkl"
 output = open(name, "wb")
-cPickle.dump( (tiling, leftover_fwt, run_settings), output, -1)
+cPickle.dump( (tiling, [], run_settings), output, -1)
 output.close()
 
 # Timestamp the copy of the settings and log files from earlier

--- a/funnelweb_generate_tiling.py
+++ b/funnelweb_generate_tiling.py
@@ -485,7 +485,10 @@ time_to_complete = (end - start).total_seconds()
 non_standard_targets_per_tile = [t.count_assigned_targets_science(
                                  include_science_standards=False) 
                                  for t in tiling]
-targets_per_tile = [t.count_assigned_targets_science(False) for t in tiling]
+                                 
+# Note: due to science and standard targets being drawn from the same list,
+# counting the science targets will also count all the standard targets
+targets_per_tile = [t.count_assigned_targets_science() for t in tiling]
 standards_per_tile = [t.count_assigned_targets_standard() for t in tiling]
 guides_per_tile = [t.count_assigned_targets_guide() for t in tiling]
 sky_per_tile = [t.count_assigned_targets_sky() for t in tiling]

--- a/funnelweb_generate_tiling.py
+++ b/funnelweb_generate_tiling.py
@@ -485,7 +485,7 @@ time_to_complete = (end - start).total_seconds()
 non_standard_targets_per_tile = [t.count_assigned_targets_science(
                                  include_science_standards=False) 
                                  for t in tiling]
-targets_per_tile = [t.count_assigned_targets_science() for t in tiling]
+targets_per_tile = [t.count_assigned_targets_science(False) for t in tiling]
 standards_per_tile = [t.count_assigned_targets_standard() for t in tiling]
 guides_per_tile = [t.count_assigned_targets_guide() for t in tiling]
 sky_per_tile = [t.count_assigned_targets_sky() for t in tiling]

--- a/funnelweb_load_tiling.py
+++ b/funnelweb_load_tiling.py
@@ -3,7 +3,7 @@
 import pickle
 import cPickle
 
-pkl_file_name = "results/171008_1145_fw_tiling.pkl"
+pkl_file_name = "results/170609_0101_fw_tiling.pkl"
 
 pkl_file = open(pkl_file_name, "rb")
 (tiling, remaining_targets, run_settings) = cPickle.load(pkl_file)

--- a/funnelweb_plotting.py
+++ b/funnelweb_plotting.py
@@ -18,9 +18,9 @@ def plot_tiling(tiling, run_settings):
     - Box & whisker plots of target/standard/guide assignments
     - Completeness progression (targets as a function of tiles)
     - Table of run_settings
-    - Histograms of targets per tile for all tiles, as well as each magnitude bin
-    - Histograms of standards per tile for all tiles, as well as each magnitude bin
-    - Histograms of guides per tile for all tiles, as well as each magnitude bin
+    - Histograms of targets per tile for all tiles, plus each magnitude bin
+    - Histograms of standards per tile for all tiles, plus each magnitude bin
+    - Histograms of guides per tile for all tiles, plus each magnitude bin
     
     Parameters
     ----------
@@ -28,7 +28,7 @@ def plot_tiling(tiling, run_settings):
         The list of TaipanTiles from a tiling run.
     
     run_settings: OrderedDict
-        An OrderedDict containing input settings and results from the tiling run.
+        OrderedDict containing input settings and results from the tiling run.
     """
     # Initialise plot, use GridSpec to have a NxM grid, write title
     plt.clf()
@@ -36,7 +36,8 @@ def plot_tiling(tiling, run_settings):
     gs.update(wspace=0.2)
     fig = plt.gcf()
     fig.set_size_inches(24., 24.)
-    plt.suptitle(run_settings["run_id"] + ": " + run_settings["description"], fontsize=30)
+    plt.suptitle(run_settings["run_id"] + ": " + run_settings["description"], 
+                 fontsize=30)
     
     # Separate targets, standards, and guides by magnitude range
     tiles_by_mag_range = []
@@ -61,32 +62,37 @@ def plot_tiling(tiling, run_settings):
         standards_by_mag_range.append(standards_for_range)
         guides_by_mag_range.append(guides_for_range)
         
-        tile_count_labels.append("Mag range: %s-%s (%s tiles)" % (mrange[0], mrange[1],
-                                 len(tiles_for_range)))
+        tile_count_labels.append("Mag range: %s-%s (%s tiles)" % (mrange[0], 
+                                                                  mrange[1],
+                                                        len(tiles_for_range)))
     
     targets_per_tile = run_settings["targets_per_tile"]
     standards_per_tile = run_settings["standards_per_tile"]
     guides_per_tile = run_settings["guides_per_tile"]
     
     # Insert the non-magnitude range specific numbers
-    tiles_by_mag_range.insert(0, [t.count_assigned_targets_science() for t in tiling]) 
-    standards_by_mag_range.insert(0, [t.count_assigned_targets_standard() for t in tiling]) 
-    guides_by_mag_range.insert(0, [t.count_assigned_targets_guide() for t in tiling])
+    tiles_by_mag_range.insert(0, [t.count_assigned_targets_science() 
+                              for t in tiling]) 
+    standards_by_mag_range.insert(0, [t.count_assigned_targets_standard() 
+                                  for t in tiling]) 
+    guides_by_mag_range.insert(0, [t.count_assigned_targets_guide() 
+                               for t in tiling])
     
-    # ------------------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     # Tile positions
-    # ------------------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     # Plot an Aitoff projection of the tile centre positions on-sky
     ax0 = fig.add_subplot(gs[0,0], projection='aitoff')
     ax0.grid(True)
     
     # Count the number of tiles per field
     coords = Counter(["%f_%f" % (tile.ra, tile.dec) for tile in tiling])
-    coords = np.array([[float(key.split("_")[0]), float(key.split("_")[1]), coords[key]] 
-                      for key in coords.keys()])
+    coords = np.array([[float(key.split("_")[0]), float(key.split("_")[1]), 
+                      coords[key]] for key in coords.keys()])
     
-    ax0_plt = ax0.scatter(np.radians(coords[:,0] - 180.), np.radians(coords[:,1]), 
-                          c=coords[:,2], marker='o', lw=0, s=3, cmap="rainbow")
+    ax0_plt = ax0.scatter(np.radians(coords[:,0] - 180.), 
+                          np.radians(coords[:,1]), c=coords[:,2], marker='o',
+                          lw=0, s=3, cmap="rainbow")
     ax0.set_title('Tile centre positions', y=1.1)
     ax0.set_axisbelow(True)
     
@@ -99,19 +105,20 @@ def plot_tiling(tiling, run_settings):
     ax0.tick_params(axis='both', which='minor', labelsize=6)
 
     
-    # ------------------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     # Box-and-whisker plots of number distributions
-    # ------------------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     # Plot box-and-whisker plots of the targets, standards, and guides
     ax1 = fig.add_subplot(gs[1,0])
-    ax1.boxplot([targets_per_tile, standards_per_tile, guides_per_tile], vert=False)
+    ax1.boxplot([targets_per_tile, standards_per_tile, guides_per_tile], 
+                vert=False)
     ax1.set_yticklabels(['T', 'S', 'G'])
     ax1.set_title('Box-and-whisker plots of number of assignments')
 
-    # ------------------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     # Number of Tiles vs Completeness
-    # ------------------------------------------------------------------------------------
-    # Plot tiling completeness as number of targets as a function of number of tiles
+    # -------------------------------------------------------------------------
+    # Plot tiling completeness as # of targets as a function of # tiles
     ax2 = fig.add_subplot(gs[2,0])
     targets_per_tile_sorted = sorted(targets_per_tile, key=lambda x: -1.*x)
     xpts = np.asarray(range(len(targets_per_tile_sorted))) + 1
@@ -119,12 +126,15 @@ def plot_tiling(tiling, run_settings):
     ax2.plot(xpts, ypts, 'k-', lw=.9)
     ax2.plot(len(tiling), np.sum(targets_per_tile), 'ro',
              label='No. of tiles: %d' % len(tiling))
-    ax2.hlines(run_settings["num_targets"], ax2.get_xlim()[0], ax2.get_xlim()[1], lw=.75,
-               colors='k', linestyles='dashed', label='100% completion')
-    ax2.hlines(0.975 * run_settings["num_targets"], ax2.get_xlim()[0], ax2.get_xlim()[1], 
-               lw=.75, colors='k', linestyles='dashdot', label='97.5% completion')
-    ax2.hlines(0.95 * run_settings["num_targets"], ax2.get_xlim()[0], ax2.get_xlim()[1], 
-               lw=.75, colors='k', linestyles='dotted', label='95% completion')
+    ax2.hlines(run_settings["num_targets"], ax2.get_xlim()[0], 
+               ax2.get_xlim()[1], lw=.75, colors='k', linestyles='dashed', 
+               label='100% completion')
+    ax2.hlines(0.975 * run_settings["num_targets"], ax2.get_xlim()[0], 
+               ax2.get_xlim()[1], lw=.75, colors='k', linestyles='dashdot', 
+               label='97.5% completion')
+    ax2.hlines(0.95 * run_settings["num_targets"], ax2.get_xlim()[0], 
+               ax2.get_xlim()[1], lw=.75, colors='k', linestyles='dotted', 
+               label='95% completion')
     ax2.legend(loc='lower right', title='Time to %3.1f comp.: %dm:%2.1fs' % (
                run_settings["tiling_completeness"] * 100., 
                int(np.floor(run_settings["mins_to_complete"])), 
@@ -135,9 +145,9 @@ def plot_tiling(tiling, run_settings):
     ax2.set_xlim([0, 1.05*len(tiling)])
     ax2.set_ylim([0, 1.05*run_settings["num_targets"]])
 
-    # ------------------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     # Table of Run Settings
-    # ------------------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     # Plot a table for referencing the run settings/results
     ax3 = fig.add_subplot(gs[3:5,0])
     col_labels = ("Parameter", "Value")
@@ -158,13 +168,14 @@ def plot_tiling(tiling, run_settings):
         else:
             fmt_table.append([key, value])
     
-    settings_tab = ax3.table(cellText=fmt_table, colLabels=col_labels, loc="center")
+    settings_tab = ax3.table(cellText=fmt_table, colLabels=col_labels, 
+                             loc="center")
     settings_tab.set_fontsize(8)
     settings_tab.scale(1.0,0.7)
     
-    # ------------------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     # Create plots for all tiles, as well as each magnitude range
-    # ------------------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     # Initialise axes lists, and colour format
     ax4 = []
     ax5 = []
@@ -176,12 +187,13 @@ def plot_tiling(tiling, run_settings):
         # Match the colours for each magnitude range
         colour = next(colour_cycler)
         
-        # --------------------------------------------------------------------------------
+        # ---------------------------------------------------------------------
         # Number of Targets per Tile
-        # --------------------------------------------------------------------------------
+        # ---------------------------------------------------------------------
         # Plot a histogram of the number of targets per tile
         ax4.append(fig.add_subplot(gs[i,1]))
-        ax4[-1].hist(tiles_by_mag_range[i], bins=np.arange(0, max(targets_per_tile)+1, 1), 
+        ax4[-1].hist(tiles_by_mag_range[i], 
+                     bins=np.arange(0, max(targets_per_tile)+1, 1), 
                      color=colour, align='right', label=label)
         #ax4[-1].vlines(run_settings["TARGET_PER_TILE"], ax4[-1].get_ylim()[0],  
         #               ax4[-1].get_ylim()[1], linestyles='dashed', colors='k', 
@@ -199,22 +211,25 @@ def plot_tiling(tiling, run_settings):
             tile_mean = 0
             tile_median = 0
         
-        ax4[-1].text(0.5, 0.5, "Mean: %i, Median: %i" % (tile_mean, tile_median),
+        ax4[-1].text(0.5, 0.5, "Mean: %i, Median: %i" % (tile_mean, 
+                                                         tile_median),
                      ha="center", transform=ax4[-1].transAxes)
         
-        # --------------------------------------------------------------------------------
+        # ---------------------------------------------------------------------
         # Number of standards per tile
-        # --------------------------------------------------------------------------------
+        # ---------------------------------------------------------------------
         # Plot a histogram of the number of standards per tile
         ax5.append(fig.add_subplot(gs[i,2]))
         ax5[-1].hist(standards_by_mag_range[i], 
                      bins=max(standards_per_tile), color=colour, 
                      align='right', label=label)
-        ax5[-1].vlines(run_settings["STANDARDS_PER_TILE"], ax5[-1].get_ylim()[0], 
-                       ax5[-1].get_ylim()[1], linestyles='dashed', colors='k', 
+        ax5[-1].vlines(run_settings["STANDARDS_PER_TILE"], 
+                       ax5[-1].get_ylim()[0], ax5[-1].get_ylim()[1], 
+                       linestyles='dashed', colors='k', 
                        label='Ideally-filled tile')
-        ax5[-1].vlines(run_settings["STANDARDS_PER_TILE_MIN"], ax5[-1].get_ylim()[0], 
-                       ax5[-1].get_ylim()[1], linestyles='dotted',  colors='k', 
+        ax5[-1].vlines(run_settings["STANDARDS_PER_TILE_MIN"],
+                       ax5[-1].get_ylim()[0], ax5[-1].get_ylim()[1],
+                       linestyles='dotted',  colors='k', 
                        label='Minimum standards per tile')
         ax5[-1].set_xlabel('No. of standards per tile')
         ax5[-1].set_ylabel('Frequency')
@@ -232,9 +247,9 @@ def plot_tiling(tiling, run_settings):
                      "Mean: %i, Median: %i" % (standard_mean, standard_median), 
                      ha="center")            
 
-        # --------------------------------------------------------------------------------
+        # ---------------------------------------------------------------------
         # Number of guides per tile
-        # --------------------------------------------------------------------------------
+        # ---------------------------------------------------------------------
         # Plot a histogram of the number of guides per fibre
         ax6.append(fig.add_subplot(gs[i,3]))
         ax6[-1].hist(guides_by_mag_range[i], bins=max(guides_per_tile), 
@@ -242,8 +257,9 @@ def plot_tiling(tiling, run_settings):
         ax6[-1].vlines(run_settings["GUIDES_PER_TILE"], ax6[-1].get_ylim()[0], 
                        ax6[-1].get_ylim()[1], linestyles='dashed', colors='k', 
                        label='Ideally-filled tile')
-        ax6[-1].vlines(run_settings["GUIDES_PER_TILE_MIN"], ax6[-1].get_ylim()[0], 
-                       ax6[-1].get_ylim()[1], linestyles='dotted', colors='k', 
+        ax6[-1].vlines(run_settings["GUIDES_PER_TILE_MIN"], 
+                       ax6[-1].get_ylim()[0], ax6[-1].get_ylim()[1],
+                       linestyles='dotted', colors='k', 
                        label='Minimum guides per tile')
         ax6[-1].set_xlabel('No. of guides per tile')
         ax6[-1].set_ylabel('Frequency')
@@ -258,7 +274,8 @@ def plot_tiling(tiling, run_settings):
             guides_median = 0
         
         ax6[-1].text(ax6[-1].get_xlim()[1]/2, ax6[-1].get_ylim()[1]/2,
-                     "Mean: %i, Median: %i" % (guides_mean, guides_median), ha="center") 
+                     "Mean: %i, Median: %i" % (guides_mean, guides_median), 
+                                               ha="center") 
 
     # Set plot titles
     ax3.set_title("Run Settings & Overview", y=0.96)
@@ -270,25 +287,28 @@ def plot_tiling(tiling, run_settings):
     name = "results/" + run_settings["run_id"] + "_tiling_run_overview.pdf"
     fig.savefig(name, fmt='pdf')
     
+    
 def create_tiling_visualisation(tiling, run_settings, increment=1000):
     """
     For increasingly larger slices of the tiling set, run the plotting code.
     
     To create a video from these:
-    ffmpeg -framerate 4 -pattern_type glob -i "*.png" -c:v libx264 -pix_fmt yuv420p xx.mp4
+    ffmpeg -framerate 4 -pattern_type glob -i "*.png" -c:v libx264 
+        -pix_fmt yuv420p xx.mp4
     
     Parameters
     ----------
     tiling: list
         The list of TaipanTiles from a tiling run.
     run_settings: OrderedDict
-        An OrderedDict containing input settings and results from the tiling run.
+        OrderedDict containing input settings and results from the tiling run.
     increment: int
-        The number of new tiles to include in each plot/frame (i.e. increment=1000 means
-        that each iteration of the loop will create a plot with 1000 more tiles than the 
-        last).
+        The number of new tiles to include in each plot/frame (i.e. 
+        increment=1000 means that each iteration of the loop will create a plot
+        with 1000 more tiles than the last).
     """
-    # Create the list of tile increments, ensuring the final number is the complete plot
+    # Create the list of tile increments, ensuring the final number is the 
+    # complete plot
     steps = list(np.arange(increment, len(tiling), increment))
     
     if steps[-1] != len(tiling):
@@ -298,6 +318,7 @@ def create_tiling_visualisation(tiling, run_settings, increment=1000):
     for frame, step in enumerate(steps):
         plot_tiling(tiling[:step], run_settings)
         
-        name = "results/visualisation/%s_overview_f%04i.png" % (run_settings["run_id"], 
-                                                              frame)
+        name = "results/visualisation/%s_overview_f%04i.png" % (
+                                                        run_settings["run_id"], 
+                                                        frame)
         plt.savefig(name)

--- a/funnelweb_tiling_settings.py
+++ b/funnelweb_tiling_settings.py
@@ -1,10 +1,10 @@
-"""File to easily contain the necessary parameters to tile the sky with FunnelWeb.
+"""File to easily contain parameters to tile the sky with FunnelWeb.
 
-Modify parameters as required - this file is duplicated at the conclusion of the run for 
-documentation purposes, along with a pickle of the results.
+Modify parameters as required - this file is duplicated at the conclusion of 
+the run for documentation purposes, along with a pickle of the results.
 
-n_cores controls whether the code runs runs a multiprocessing implementation or not, with
-the specific implementation determined by the "backend" parameter.
+n_cores controls whether the code runs runs a multiprocessing implementation or
+not, with the specific implementation determined by the "backend" parameter.
     n_cores = 0 --> single core (serial) implementation
     n_cores = 1 --> "single core" multiprocessing implementation
     n_cores > 1 --> multi core (parallel) implementation
@@ -21,13 +21,14 @@ from collections import OrderedDict
 # Input catalogue and priority list
 input_catalogue = ("/priv/mulga1/arains/Catalogues/fw_input_catalogue.fits")
 input_priorities = ("/priv/mulga1/arains/Catalogues/fw_priorities.fits")
-sky_catalogue = ("/priv/mulga1/arains/Catalogues/skyfibers_v17_gaia_ucac4_final.fits")
+sky_catalogue = ("/priv/mulga1/arains/Catalogues/"
+                 "skyfibers_v17_gaia_ucac4_final.fits")
 
 # Ordered dictionary, so that format is always the same when writing to a file 
 
 # Dictionary of *all* parameters required to construct taipan.fwtiling.FWTiler
 # e.g. fwtiler = FWTiler(**tiler_input)
-tiler_input = OrderedDict([("completeness_targets", [0.99, 0.99, 0.99, 0.99]),
+tiler_input = OrderedDict([("completeness_targets", [0.99, 0.99, 0.99, 0.25]),
                            ("ranking_method", "priority-expsum"),
                            ("disqualify_below_min", True),
                            ("tiling_method", "SH"),
@@ -39,7 +40,8 @@ tiler_input = OrderedDict([("completeness_targets", [0.99, 0.99, 0.99, 0.99]),
                            ("dec_min", -90),
                            ("dec_max", 0),
                            ("mag_ranges", [[5,8],[7,10],[9,12],[11,14]]),
-                           ("mag_ranges_prioritise", [[5,7],[7,9],[9,11],[11,12]]),
+                           ("mag_ranges_prioritise", 
+                           [[5,7],[7,9],[9,11],[11,12]]),
                            ("priority_normal", 2),
                            ("prioritise_extra", 2),
                            ("tile_unpick_method", "combined_weighted"),
@@ -63,7 +65,7 @@ tiler_input = OrderedDict([("completeness_targets", [0.99, 0.99, 0.99, 0.99]),
 script_settings = OrderedDict([("input_catalogue", input_catalogue),
                                ("input_priorities", input_priorities),
                                ("sky_catalogue", sky_catalogue),
-                               ("tab_type", "fw"),
+                               ("tab_type", "gaia"),
                                ("gal_lat_limit", 0),
                                ("standard_frac", 0.1),
                                ("guide_range", [8,10.5]),
@@ -74,8 +76,9 @@ script_settings = OrderedDict([("input_catalogue", input_catalogue),
                                ("GUIDES_PER_TILE_MIN", 3),
                                ("SKY_PER_TILE", 7),
                                ("SKY_PER_TILE_MIN", 7),
-                               ("QUAD_RADII", [tp.TILE_RADIUS, 8164.03, 4082.02, 0.]),
+                               ("QUAD_RADII", 
+                               [tp.TILE_RADIUS, 8164.03, 4082.02, 0.]),
                                ("QUAD_PER_RADII", [3, 3, 1]),
-                               ("use_colour_cut", True),
+                               ("use_colour_cut", False),
                                ("colour_index_cut", 0.5)])
                         

--- a/funnelweb_tiling_settings.py
+++ b/funnelweb_tiling_settings.py
@@ -76,5 +76,6 @@ script_settings = OrderedDict([("input_catalogue", input_catalogue),
                                ("SKY_PER_TILE_MIN", 7),
                                ("QUAD_RADII", [tp.TILE_RADIUS, 8164.03, 4082.02, 0.]),
                                ("QUAD_PER_RADII", [3, 3, 1]),
-                               ("use_colour_cut", False)])
+                               ("use_colour_cut", True),
+                               ("colour_index_cut", 0.5)])
                         

--- a/funnelweb_tiling_settings.py
+++ b/funnelweb_tiling_settings.py
@@ -19,8 +19,9 @@ import taipan.core as tp
 from collections import OrderedDict
 
 # Input catalogue and priority list
-catalogue = ("/priv/mulga1/arains/Catalogues/fw_input_catalogue.fits")
-priorities = ("/priv/mulga1/arains/Catalogues/fw_priorities.fits")
+input_catalogue = ("/priv/mulga1/arains/Catalogues/fw_input_catalogue.fits")
+input_priorities = ("/priv/mulga1/arains/Catalogues/fw_priorities.fits")
+sky_catalogue = ("/priv/mulga1/arains/Catalogues/skyfibers_v17_gaia_ucac4_final.fits")
 
 # Ordered dictionary, so that format is always the same when writing to a file 
 
@@ -55,11 +56,13 @@ tiler_input = OrderedDict([("completeness_targets", [0.99, 0.99, 0.99, 0.99]),
                            ("assign_sky_first", True),
                            ("n_cores", 0),
                            ("backend", "multiprocessing"),
-                           ("enforce_min_tile_score", True)])
+                           ("enforce_min_tile_score", True),
+                           ("assign_sky_fibres", True)])
  
 # Dictionary of additional parameters not required by FWTiler            
-script_settings = OrderedDict([("input_catalogue", catalogue),
-                               ("input_priorities", priorities),
+script_settings = OrderedDict([("input_catalogue", input_catalogue),
+                               ("input_priorities", input_priorities),
+                               ("sky_catalogue", sky_catalogue),
                                ("tab_type", "fw"),
                                ("gal_lat_limit", 0),
                                ("standard_frac", 0.1),

--- a/funnelweb_tiling_settings.py
+++ b/funnelweb_tiling_settings.py
@@ -28,7 +28,7 @@ sky_catalogue = ("/priv/mulga1/arains/Catalogues/"
 
 # Dictionary of *all* parameters required to construct taipan.fwtiling.FWTiler
 # e.g. fwtiler = FWTiler(**tiler_input)
-tiler_input = OrderedDict([("completeness_targets", [0.99, 0.99, 0.99, 0.25]),
+tiler_input = OrderedDict([("completeness_targets", [0.99, 0.99, 0.99, 0.10]),
                            ("ranking_method", "priority-expsum"),
                            ("disqualify_below_min", True),
                            ("tiling_method", "SH"),
@@ -44,9 +44,9 @@ tiler_input = OrderedDict([("completeness_targets", [0.99, 0.99, 0.99, 0.25]),
                            [[5,7],[7,9],[9,11],[11,12]]),
                            ("priority_normal", 2),
                            ("prioritise_extra", 2),
-                           ("tile_unpick_method", "combined_weighted"),
+                           ("tile_unpick_method", "sequential"),
                            ("combined_weight", 4.0),
-                           ("sequential_ordering", (1,2)),
+                           ("sequential_ordering", (2,1)),
                            ("rank_supplements", False),
                            ("repick_after_complete", False),
                            ("exp_base", 3.0),
@@ -79,6 +79,6 @@ script_settings = OrderedDict([("input_catalogue", input_catalogue),
                                ("QUAD_RADII", 
                                [tp.TILE_RADIUS, 8164.03, 4082.02, 0.]),
                                ("QUAD_PER_RADII", [3, 3, 1]),
-                               ("use_colour_cut", False),
+                               ("use_colour_cut", True),
                                ("colour_index_cut", 0.5)])
                         

--- a/taipan/core.py
+++ b/taipan/core.py
@@ -3202,9 +3202,10 @@ class TaipanTile(TaipanPoint):
             
         disqualify_below_min : bool
             Denotes whether to
-            rank tiles with a nubmer of guides below :any:`GUIDES_PER_TILE_MIN`
-            or a number of standards below :any:`STANDARDS_PER_TILE_MIN` a
-            score of 0. Defaults to True.
+            rank tiles with a number of guides below :any:`GUIDES_PER_TILE_MIN`,
+            a number of standards below :any:`STANDARDS_PER_TILE_MIN` or a
+            number of skies below :any:`SKY_PER_TILE_MIN`score of 0. 
+            Defaults to True.
             
         exp_base : float
             The exponential base used for 'priority-expsum` tile scores.
@@ -3230,11 +3231,24 @@ class TaipanTile(TaipanPoint):
         if method not in SCORE_METHODS:
             raise ValueError('Scoring method must be one of %s' 
                 % str(SCORE_METHODS))
-
-        # Bail out now if tile doesn't meet guide or standards requirements
+        
+        # Count the number of sky fibres that have been allocated, but have 
+        # not yet been assigned targets. This must be considered in cases
+        # where we aren't allocating actual targets to the sky fibres, but
+        # are still marking
+        allocated_but_not_assigned_sky = len([fibre for fibre in self.fibres 
+                                              if self._fibres[fibre] == "sky"])
+                                                                         
+        # Bail out now if tile doesn't meet guide/standard/sky requirements
+        # i.e. if the tile does not have the minimum number of guides,  
+        # standards, or either the minimum allocated/assigned sky fibres
+        # (that it is acceptable to have > SKY_PER_TILE fibres assigned with
+        # "sky" or allocated with actual sky targets)
         if disqualify_below_min and (self.count_assigned_targets_guide() 
             < GUIDES_PER_TILE_MIN or self.count_assigned_targets_standard()
-            < STANDARDS_PER_TILE_MIN):
+            < STANDARDS_PER_TILE_MIN or (self.count_assigned_targets_sky() 
+            < SKY_PER_TILE_MIN and allocated_but_not_assigned_sky 
+            < SKY_PER_TILE_MIN)):
             return 0.
 
         # Get all the science targets
@@ -4131,12 +4145,12 @@ class TaipanTile(TaipanPoint):
         
         # Each TaipanTile object will have a different set of fibres reserved as sky 
         # fibres. Grab these and assign sky "targets" to them
-        FIBRES_SKY = [fibre for fibre in self.fibres if self.fibres[fibre] ==
+        FIBRES_SKY = [fibre for fibre in self.fibres if self._fibres[fibre] ==
                       "sky"]
 
         # Calculate rest positions for all sky fibres
-        fibre_posns = {fibre: self.compute_fibre_posn(fibre) for fibre in
-                       FIBRES_SKY}
+        fibre_posns_sky = {fibre: self.compute_fibre_posn(fibre) for fibre in
+                           FIBRES_SKY}
         
         # Calculate rest positions for all non-guide fibres
         # DONE: Consideration for avoiding standard fibres
@@ -4150,7 +4164,7 @@ class TaipanTile(TaipanPoint):
 
         # Reset the sky fibres
         for fibre in FIBRES_SKY:
-            self.fibres[fibre] = None
+            self._fibres[fibre] = None
         
         # Create a copy
         sky_this_tile = sky_targets[:]
@@ -4159,7 +4173,8 @@ class TaipanTile(TaipanPoint):
             sky_this_tile = [g for g in sky_this_tile
                              if g.dist_point((self.ra, self.dec, )) <
                              TILE_RADIUS]
-
+        
+        # Sort the sky targets
         if rank_sky:
             logging.debug('Sorting input sky list by priority')
             sky_this_tile.sort(key=lambda x: -1 * x.priority)
@@ -4168,7 +4183,7 @@ class TaipanTile(TaipanPoint):
             # Instead of having randomly ordered sky, let's rank them
             # by the distance to their nearest sky fibre
             sky_this_tile.sort(key=lambda x: np.min([
-                x.dist_point(posn) for posn in fibre_posns.itervalues()
+                x.dist_point(posn) for posn in fibre_posns_sky.itervalues()
             ]))
 
         # Assign up to SKY_PER_TILE sky, check how many have already
@@ -4187,8 +4202,8 @@ class TaipanTile(TaipanPoint):
                 continue
 
             # Identify the closest fibre to this target
-            fibre_dists = {fibre: sky.dist_point(fibre_posns[fibre])
-                for fibre in fibre_posns}
+            fibre_dists = {fibre: sky.dist_point(fibre_posns_sky[fibre])
+                for fibre in fibre_posns_sky}
             permitted_fibres = sorted([fibre for fibre in fibre_dists
                 if fibre_dists[fibre] < PATROL_RADIUS],
                 key=lambda x: fibre_dists[x])
@@ -4197,7 +4212,7 @@ class TaipanTile(TaipanPoint):
             logging.debug('Looking to add to fiber...')
             candidate_found = False
             while not(candidate_found) and len(permitted_fibres) > 0:
-                if self._fibres[permitted_fibres[0]] == "sky":
+                if self._fibres[permitted_fibres[0]] == None:
                     # Assign the target and 'pop' it from the input list
                     self._fibres[permitted_fibres[0]] = sky_this_tile.pop(0)
                     candidate_found = True
@@ -4214,7 +4229,7 @@ class TaipanTile(TaipanPoint):
                 sky_this_tile.pop(0)
 
         assigned_objs = self.get_assigned_targets()
-
+        
         # If we have not assigned to the minimum accepted number of sky fibres,
         # but have exhausted all possibilities, we now have to remove science
         # targets to reach the minimum accepted.
@@ -4294,7 +4309,7 @@ class TaipanTile(TaipanPoint):
                     
                 for f in fibres_for_removal:
                     removed_targets.append(self.unassign_fibre(f))
-                    
+ 
                 self._fibres[permitted_fibres[0]] = sky_this_tile[i]
                 assigned_sky += 1
                 
@@ -4302,7 +4317,7 @@ class TaipanTile(TaipanPoint):
                 burn = problem_targets.pop(i)
                 burn = problem_targets_rankings.pop(i)
                 burn = sky_this_tile.pop(i)
-
+        
         return removed_targets
         
 

--- a/taipan/core.py
+++ b/taipan/core.py
@@ -1416,11 +1416,12 @@ def compute_target_difficulties(target_list, full_target_list=None,
     if full_target_list:
         if verbose:
             'Checking target_list against full_target_list...'
-        # Notes about np.in1d - fails for object arrays that are unsortable. This is not a
-        # problem for the Taipan code, but for FunnelWeb, which implements object level
-        # equivalence (i.e. __eq__, __ne__, __cmp__), this check will always raise an 
-        # exception, even when the arrays are subsets. Future versions of numpy will fix 
-        # this, but for now a workaround is needed. See issue links for more details:
+        # Notes about np.in1d - fails for object arrays that are unsortable. 
+        # This is not a problem for the Taipan code, but for FunnelWeb, which 
+        # implements object level equivalence (i.e. __eq__, __ne__, __cmp__), 
+        # this check will always raise an exception, even when the arrays are 
+        # subsets. Future versions of numpy will fix this, but for now a 
+        # workaround is needed. See issue links for more details:
         # 1) https://github.com/numpy/numpy/issues/9874
         # 2) https://github.com/numpy/numpy/issues/9914
         if not isinstance(target_list[0], FWTarget) \
@@ -1482,7 +1483,8 @@ def compute_target_difficulties(target_list, full_target_list=None,
     return
 
 
-def targets_in_range(ra, dec, target_list, dist, leafsize=BREAKEVEN_KDTREE, tree=None):
+def targets_in_range(ra, dec, target_list, dist, leafsize=BREAKEVEN_KDTREE, 
+                     tree=None):
     """
     Return the subset of ``target_list`` within ``dist`` of (``ra``, ``dec``).
 
@@ -2390,8 +2392,8 @@ class TaipanTarget(TaipanPoint):
 
 
 class FWTarget(TaipanTarget):
-    """Derived class for the FunnelWeb survey, primarily to allow object equivalence and
-    having sky fibres
+    """Derived class for the FunnelWeb survey, primarily to allow object 
+    equivalence.
     """
     def __init__(self, idn, ra, dec, usposn=None, priority=1, standard=False,
                  guide=False, difficulty=0, mag=None,
@@ -2419,20 +2421,21 @@ class FWTarget(TaipanTarget):
         mag : float, optional
             Target magnitude. Defaults to None.
         h0, vpec, lowz : Boolean, optional
-            Booleans denoting if a target is an H0 target, a low-redshift (lowz)
-            target, or a peculiar velocity (vpec) target. All default to False.
+            Booleans denoting if a target is an H0 target, a low-redshift 
+            (lowz) target, or a peculiar velocity (vpec) target. All default 
+            to False.
         science : Boolean, optional
             Denotes this target as a science target. Defaults to True
         assign_science : Boolean, optional
-            Do we automatically assign the science flag based on standard and guide 
+            Do we automatically assign the science flag based on standard/guide 
             flags? Defaults to True
         sky: boolean
             Denotes this target as a science target. Defaults to False.
         """
         # Initialise the base class
-        TaipanTarget.__init__(self, idn, ra, dec, usposn, priority, standard, guide, 
-                              difficulty, mag, h0, vpec, lowz, science, assign_science,
-                              sky)
+        TaipanTarget.__init__(self, idn, ra, dec, usposn, priority, standard,
+                              guide, difficulty, mag, h0, vpec, lowz, science,
+                              assign_science, sky)
         
     def __repr__(self):
         return 'FW TGT %s' % str(self._idn)
@@ -2440,24 +2443,28 @@ class FWTarget(TaipanTarget):
     def __str__(self):
         return 'FW TGT %s' % str(self._idn)
 
-    # Two FWTargets should be considered equal if they have the same ID, and status as
-    # science/standard/guide/sky targets.
+    # Two FWTargets should be considered equal if they have the same ID, and 
+    # status as science/standard/guide/sky targets.
     def __eq__(self, other):
         if isinstance(other, self.__class__):
-            return (self.idn == other.idn) and (self.standard == other.standard) \
-                   and (self.guide == other.guide) and (self.sky == other.sky)
+            return ((self.idn == other.idn) 
+                    and (self.standard == other.standard)
+                    and (self.guide == other.guide) 
+                    and (self.sky == other.sky))
         return False
     
     def __ne__(self, other):
         if isinstance(other, self.__class__):
-            return not((self.idn == other.idn) and (self.standard == other.standard) 
-                    and (self.guide == other.guide) and (self.sky == other.sky))
+            return not((self.idn == other.idn) 
+                       and (self.standard == other.standard) 
+                       and (self.guide == other.guide)
+                       and (self.sky == other.sky))
         return True
     
     def __cmp__(self, other):
         if isinstance(other, self.__class__):
-            if (self.idn == other.idn) and (self.standard == other.standard) \
-                and (self.guide == other.guide) and (self.sky == other.sky):
+            if ((self.idn == other.idn) and (self.standard == other.standard) 
+                and (self.guide == other.guide) and (self.sky == other.sky)):
                 return 0
         return 1
         
@@ -4143,8 +4150,8 @@ class TaipanTile(TaipanPoint):
 
         removed_targets = []
         
-        # Each TaipanTile object will have a different set of fibres reserved as sky 
-        # fibres. Grab these and assign sky "targets" to them
+        # Each TaipanTile object will have a different set of fibres reserved  
+        # as sky fibres. Grab these and assign sky "targets" to them
         FIBRES_SKY = [fibre for fibre in self.fibres if self._fibres[fibre] ==
                       "sky"]
 
@@ -4303,7 +4310,7 @@ class TaipanTile(TaipanPoint):
                     burn = sky_this_tile.pop(i)
                     continue
                     
-                # Remove the offending targets from the tile, and assign the sky
+                # Remove offending targets from the tile, and assign the sky
                 fibres_for_removal = [f for (f, t) in self._fibres.iteritems()
                     if t in problem_targets[i]]
                     

--- a/taipan/fwtiling.py
+++ b/taipan/fwtiling.py
@@ -1,9 +1,10 @@
-"""The FWTiler object exists to encapsulate taipan.tiling settings, wrap functions
-associated with taipan.core (i.e. objects derived from TaipanPoint) and perform FunnelWeb
-specific tiling operations. The intent of this class is separate the logic of *tiling* 
-from the objects being *tiled* in a way that makes the code easier to interpret. The 
-class hosts the various setup parameters associated with the various tiling algorithms,
-freeing up function calls from repeated parameters.
+"""The FWTiler object exists to encapsulate taipan.tiling settings, wrap
+functions associated with taipan.core (i.e. objects derived from TaipanPoint) 
+and perform FunnelWeb specific tiling operations. The intent of this class is 
+separate the logic of *tiling* from the objects being *tiled* in a way that 
+makes the code easier to interpret. The class hosts the various setup 
+parameters associated with the various tiling algorithms, freeing up function 
+calls from repeated parameters.
 
 Function heirarchy as follows:
  - FWTiler.generate_tiling()
@@ -20,7 +21,7 @@ And view with:
 For other usage, visit:
     https://github.com/rkern/line_profiler
 
-Where all functions with an #@profile decorator will be profiled - uncomment beforehand.
+All functions with an #@profile decorator will be profiled - uncomment before.
 """
 import logging
 import core as tp
@@ -38,30 +39,36 @@ from collections import Counter, OrderedDict
 from scipy.spatial import cKDTree
 
 class FWTiler(object):
-    """FunnelWeb Tiler object to encapsulate tiling settings, wrap tiling functions, and
-    perform tiling operations for FunnelWeb. 
+    """FunnelWeb Tiler object to encapsulate tiling settings, wrap tiling 
+    functions, and perform tiling operations for FunnelWeb. 
     """
     def __init__(self, completeness_targets=[0.99,0.99,0.99,0.99], 
                  ranking_method='priority-expsum', disqualify_below_min=True, 
                  tiling_method='SH', randomise_pa=True, randomise_SH=True, 
-                 tiling_file='ipack.3.8192.txt', ra_min=0.0, ra_max=360.0, dec_min=-90.0, 
-                 dec_max=90.0, mag_ranges=[[5,8],[7,10],[9,12],[11,14]],
-                 mag_ranges_prioritise=[[5,7],[7,8],[9,10],[11,12]], priority_normal=2, 
-                 prioritise_extra=2, tile_unpick_method='combined_weighted', 
-                 combined_weight=4.0, sequential_ordering=(2, 1), rank_supplements=False, 
-                 repick_after_complete=True, exp_base=3.0, recompute_difficulty=True, 
-                 overwrite_existing=True, check_tile_radius=True, 
-                 consider_removed_targets=False, allow_standard_targets=True, 
-                 assign_sky_first=True, n_cores=1, backend="multiprocessing", 
-                 enforce_min_tile_score=True, assign_sky_fibres=False):
-        """Constructor for FWTiler. Takes as parameters the various settings needed to 
-        unpick and rank individual tiles, as well as tile the sky as a whole.
+                 tiling_file='ipack.3.8192.txt', ra_min=0.0, ra_max=360.0, 
+                 dec_min=-90.0, dec_max=90.0, 
+                 mag_ranges=[[5,8],[7,10],[9,12],[11,14]],
+                 mag_ranges_prioritise=[[5,7],[7,8],[9,10],[11,12]], 
+                 priority_normal=2, prioritise_extra=2, 
+                 tile_unpick_method='combined_weighted', combined_weight=4.0,
+                 sequential_ordering=(2, 1), rank_supplements=False, 
+                 repick_after_complete=True, exp_base=3.0, 
+                 recompute_difficulty=True, overwrite_existing=True, 
+                 check_tile_radius=True, consider_removed_targets=False, 
+                 allow_standard_targets=True, assign_sky_first=True, n_cores=1,
+                 backend="multiprocessing", enforce_min_tile_score=True,
+                 assign_sky_fibres=False):
+        """Constructor for FWTiler. Takes as parameters the various settings
+        needed to unpick and rank individual tiles, as well as tile the sky as
+        a whole.
         
         Parameters
         ----------
         completeness_targets: list of floats 
-            A list of floats in the range (0, 1] denoting the science target completeness 
-            to stop at per magnitude range. Defaults to 0.99 (99% completeness).
+            A list of floats in the range (0, 1] denoting the science target
+            completeness to stop at per magnitude range. 
+            Defaults to [0.99,0.99,0.99,0.99] (99% completeness for all 
+            magnitude ranges).
         
         ranking_method: string
             The scheme to use for ranking the tiles. See the documentation for 
@@ -69,102 +76,111 @@ class FWTiler(object):
         
         disqualify_below_min: boolean
             Denotes whether to rank tiles with a number of guides below 
-            GUIDES_PER_TILE_MIN or a number of standards below STANDARDS_PER_TILE_MIN a 
-            score of 0. Defaults to True.
+            GUIDES_PER_TILE_MIN, standards below STANDARDS_PER_TILE_MIN or sky
+            below SKY_PER_TILE_MIN with a score of 0. Defaults to True.
         
         tiling_method: string
             The method by which to generate a tiling set. Currently, only 'SH' 
             (Sloane-Harding tiling centres) are available.
         
         randomise_pa: boolean
-            Optional Boolean, denoting whether to randomise the pa of seed tiles or not. 
-            Defaults to True.
+            Optional Boolean, denoting whether to randomise the pa of seed 
+            tiles or not. Defaults to True.
         
         randomise_SH: boolean
-            Optional Boolean, denoting whether or not to randomise the RA of the 'seed' of
-            the SH tiling. Defaults to True.
+            Optional Boolean, denoting whether or not to randomise the RA of 
+            the 'seed' of the SH tiling. Defaults to True.
         
         tiling_file: string
-            The SH tiling file to use for generating tiling centres. Defaults to 
-            'ipack.3.8192.txt'.
+            The SH tiling file to use for generating tiling centres. Defaults 
+            to 'ipack.3.8192.txt'.
         
         ra_min, ra_max, dec_min, dec_max: float
-            The RA and Dec bounds of the region to be considered, in decimal degrees. To 
-            have an RA range spanning across 0 deg RA, either use a negative value for 
-            ra_min, or give an ra_min > ra_max.
+            The RA and Dec bounds of the region to be considered, in decimal 
+            degrees. To have an RA range spanning across 0 deg RA, either use a
+            negative value for ra_min, or give an ra_min > ra_max.
         
         mag_ranges: list
             The magnitude ranges for each set of tiles, of the form:
             [[r1_min, r1_max], [r2_min, r2_max], ....]
         
         mag_ranges_prioritise: list
-            The magnitude ranges to add extra priority to within each set of tiles. Of the 
-            form: [[r1p_min, r1p_max], [r2p_min, r2p_max], ....]
+            The magnitude ranges to add extra priority to within each set of
+            tiles. Of the form: [[r1p_min, r1p_max], [r2p_min, r2p_max], ....]
         
         priority_normal: float
-            The standard priority level. Completeness is assessed at this priority level
-            for stars in the priority magnitude range.
+            The standard priority level. Completeness is assessed at this 
+            priority level for stars in the priority magnitude range.
         
         prioritise_extra: float
-            The additional priority to add within each of the mag_range_prioritise
+            The additional priority to add within each of the stars in
+            mag_range_prioritise
         
         tile_unpick_method: string
-            The scheme to be used for unpicking tiles. Defaults to 'sequential'. See the 
-            documentation for TaipanTile.unpick_tile for details.
+            The scheme to be used for unpicking tiles. Defaults to 
+            'sequential'. See the documentation for TaipanTile.unpick_tile for 
+            details.
         
         combined_weight: float
-            Additional argument to be used in the tile unpicking process. See the 
-            documentation for TaipanTile.unpick_tile for details.
+            Additional argument to be used in the tile unpicking process. See 
+            the documentation for TaipanTile.unpick_tile for details.
             
         sequential_ordering: tuple 
-            Additional argument to be used in the tile unpicking process. See the 
-            documentation for TaipanTile.unpick_tile for details.
+            Additional argument to be used in the tile unpicking process. See
+            the documentation for TaipanTile.unpick_tile for details.
         
         rank_supplements: boolean
-            Optional Boolean value, denoting whether to attempt to assign guides/standards 
-            in priority order. Defaults to False.
+            Optional Boolean value, denoting whether to attempt to assign
+            guides/standards in priority order. Defaults to False.
         
         repick_after_complete: boolean
-            Boolean value, denoting whether to repick each tile after unpicking. Defaults 
-            to True.
+            Boolean value, denoting whether to repick each tile after 
+            unpicking. Defaults to True.
         
         exp_base : float, optional
-            For priority-expsum, this is the base for the exponent (default 3.0)        
+            For priority-expsum, is the base for the exponent (default 3.0)
         
         recompute_difficulty: boolean
-            Boolean value, denoting whether to recompute target difficulties after a tile 
-            is moved to the results list. For FunnelWeb, it also means recompute for each 
-            mag range. Defaults to True.
+            Boolean value, denoting whether to recompute target difficulties 
+            after a tile is moved to the results list. For FunnelWeb, it also
+            means recompute for each mag range. Defaults to True.
         
         overwrite_existing: boolean
-            Additional argument to be used in the tile unpicking process. See the 
-            documentation for TaipanTile.unpick_tile for details. Defaults to true.
+            Additional argument to be used in the tile unpicking process. 
+            See the documentation for TaipanTile.unpick_tile for details. 
+            Defaults to true.
         
         check_tile_radius: boolean
-            Additional argument to be used in the tile unpicking process. See the 
-            documentation for TaipanTile.unpick_tile for details. Defaults to true.
+            Additional argument to be used in the tile unpicking process. 
+            See the documentation for TaipanTile.unpick_tile for details. 
+            Defaults to true.
             
         consider_removed_targets: boolean
-            Additional argument to be used in the tile unpicking process. See the 
-            documentation for TaipanTile.unpick_tile for details. Defaults to False.
+            Additional argument to be used in the tile unpicking process. 
+            See the documentation for TaipanTile.unpick_tile for details. 
+            Defaults to False.
             
         allow_standard_targets: boolean
-            Additional argument to be used in the tile unpicking process. See the 
-            documentation for TaipanTile.unpick_tile for details. Defaults to true.
+            Additional argument to be used in the tile unpicking process. 
+            See the documentation for TaipanTile.unpick_tile for details. 
+            Defaults to true.
              
         assign_sky_first
-            Additional argument to be used in the tile unpicking process. See the 
-            documentation for TaipanTile.unpick_tile for details. Defaults to true.
+            Additional argument to be used in the tile unpicking process. 
+            See the documentation for TaipanTile.unpick_tile for details. 
+            Defaults to true.
             
         n_cores: int
-            The number of processor cores to be used for the tiling process. n_cores=0 is
-            the standard serial method, n_cores=1 is serial, but using the multiprocessing
-            implementation, n_cores >= 2 is done in parallel.
+            The number of processor cores to be used for the tiling process. 
+            n_cores=0 is the standard serial method, n_cores=1 is serial, but 
+            using the multiprocessing implementation, n_cores >= 2 is done in 
+            parallel.
         backend: string
-            The backend to be used for the joblib library - either "threading" or 
-            "multiprocessing".
+            The backend to be used for the joblib library - either "threading"
+            or "multiprocessing".
         enforce_min_tile_score: boolean
-            Whether a selected tile should be greater than some minimum tile score.
+            Whether a selected tile should be greater than some minimum tile
+            score.
         assign_sky_fibres: boolean
             Whether to assign sky targets or not. Defaults to False.
         """
@@ -202,12 +218,12 @@ class FWTiler(object):
         self._enforce_min_tile_score_original = None    
         self._assign_sky_fibres = None
         
-        # Insert the passed values. Doing it like this forces the setter functions to be 
-        # called, which provides error checking
+        # Insert the passed values. Doing it like this forces the setter 
+        # functions to be called, which provides error checking
         self.completeness_targets = completeness_targets
         self.ranking_method = ranking_method
         self.disqualify_below_min = disqualify_below_min
-        self.disqualify_below_min_original = disqualify_below_min # "Memory" param
+        self.disqualify_below_min_original = disqualify_below_min # Memory
         self.tiling_method = tiling_method
         self.randomise_pa = randomise_pa
         self.randomise_SH = randomise_SH
@@ -235,7 +251,7 @@ class FWTiler(object):
         self.n_cores = n_cores
         self.backend = backend
         self.enforce_min_tile_score = enforce_min_tile_score
-        self.enforce_min_tile_score_original = enforce_min_tile_score # "Memory" param
+        self.enforce_min_tile_score_original = enforce_min_tile_score # Memory
         self.assign_sky_fibres = assign_sky_fibres
         
         # Not input params (don't currently have getters or setters)
@@ -244,17 +260,20 @@ class FWTiler(object):
         self.sky_tree = None
         self.completion_target = None
         
-        # If completeness_targets, mag_ranges, and mag_range_priorities have been set, 
-        # they should all have the same length
-        if self.completeness_targets and self.mag_ranges and self.mag_ranges_prioritise:
-            if len(self.completeness_targets) != len(self.mag_ranges) \
-                and len(self.completeness_targets) != len(self.mag_ranges_prioritise):
+        # If completeness_targets, mag_ranges, and mag_range_priorities have 
+        # been set, they should all have the same length
+        if (self.completeness_targets and self.mag_ranges 
+            and self.mag_ranges_prioritise):
+            if (len(self.completeness_targets) != len(self.mag_ranges)
+                and len(self.completeness_targets) 
+                != len(self.mag_ranges_prioritise)):
                 raise ValueError("completeness_targets, mag_ranges, and "
-                                 "mag_ranges_priorities should have the same length")
+                                 "mag_ranges_priorities should have the "
+                                 "same length")
    
-    # ------------------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     # Attribute handling
-    # ------------------------------------------------------------------------------------   
+    # -------------------------------------------------------------------------
     @property
     def completeness_targets(self):
         return self._completeness_target
@@ -264,7 +283,7 @@ class FWTiler(object):
         if value is None: 
             raise Exception('completeness_targets may not be blank')
         elif np.all([ct <= 0. or ct > 1 for ct in value]):
-            raise ValueError('completeness_targets must be in the range (0, 1]')
+            raise ValueError('completeness_targets must be in range (0, 1]')
         self._completeness_target = value
         
     @property
@@ -309,7 +328,8 @@ class FWTiler(object):
         if value is None: 
             raise Exception('tiling_method may not be blank')
         elif value not in TILING_METHODS:
-            raise ValueError('tiling_method must be one of %s' % str(TILING_METHODS))
+            raise ValueError('tiling_method must be one of %s' % str(
+                                                               TILING_METHODS))
         self._tiling_method = value
         
     @property
@@ -598,17 +618,18 @@ class FWTiler(object):
     
     @property
     def min_tile_score(self):
-        # Return the minimum tile score - the score a tile would have it it had a single
-        # priority target. When using this, we do not consider any tiles with a lower
-        # score than this.
+        # Return the minimum tile score - the score a tile would have it it had
+        # a single priority target. When using this, we do not consider any 
+        # tiles with a lower score than this.
         return self.exp_base**self.completeness_priority    
        
     @property
     def unpick_settings(self):
-        # This property exists to simplify the need for a non-method function when using
-        # multiprocessing (as method functions cannot be pickled to be sent to the sub-
-        # processes without some difficulty). The generated dictionary can be passed to
-        # the now external function without the need for a large parameter list.
+        # This property exists to simplify the need for a non-method function 
+        # when using multiprocessing (as method functions cannot be pickled to
+        # be sent to the sub-processes without some difficulty). The generated
+        # dictionary can be passed to the now external function without the
+        # need for a large parameter list.
         return {"overwrite_existing":self.overwrite_existing, 
                 "check_tile_radius":self.check_tile_radius,
                 "recompute_difficulty":self.recompute_difficulty,
@@ -623,9 +644,9 @@ class FWTiler(object):
                 "assign_sky_fibres":self.assign_sky_fibres}
     
     
-    # ------------------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     # taipan.tiling wrapper functions
-    # ------------------------------------------------------------------------------------    
+    # -------------------------------------------------------------------------
     def gen_pa(self):
         """FWTiler wrapper for tiling.gen_pa(randomise_pa)
         """
@@ -633,13 +654,17 @@ class FWTiler(object):
     
         
     def compute_bounds(self):
-        """FWTiler wrapper for tiling.compute_bounds(ra_min, ra_max, dec_min, dec_max)
+        """FWTiler wrapper for:
+        tiling.compute_bounds(ra_min, ra_max, dec_min, dec_max)
         
-        Forces the stored RA/DEC limits to their correct format. Use after FWTiler object
-        creation to ensure inputs are appropriate before commencing tiling.
+        Forces the stored RA/DEC limits to their correct format. Use after 
+        FWTiler object creation to ensure inputs are appropriate before 
+        commencing tiling.
         """
-        ra_min, ra_max, dec_min, dec_max = tl.compute_bounds(self.ra_min, self.ra_max, 
-                                                             self.dec_min, self.dec_max)
+        ra_min, ra_max, dec_min, dec_max = tl.compute_bounds(self.ra_min, 
+                                                             self.ra_max, 
+                                                             self.dec_min, 
+                                                             self.dec_max)
         self.ra_min = ra_min
         self.ra_max = ra_max
         self.dec_min = dec_min
@@ -647,30 +672,34 @@ class FWTiler(object):
      
         
     def is_within_bounds(self, tile, compute_bounds_forcoords=True):
-        """FWTiler wrapper for tiling.is_within_bounds(tile, ra_min, ra_max, dec_min, 
-                                    dec_max, compute_bounds_forcoords=True)
+        """FWTiler wrapper for:
+         tiling.is_within_bounds(tile, ra_min, ra_max, dec_min, dec_max, 
+                                 compute_bounds_forcoords=True)
                                     
         Parameters
         ----------
         tile: TaipanTile
             The TaipanTile instance to check.
         compute_bounds_forcoords: boolean
-            Boolean value, denoting whether to use the tl.convert_bounds function
-            function to ensure the bounds are in standard format. Defaults to True.
+            Boolean value, denoting whether to use the tl.convert_bounds 
+            function to ensure the bounds are in standard format. 
+            Defaults to True.
             
         Returns
         -------
         within_bounds: boolean
-            Boolean value denoting whether the tile centre is within the bounds (True) or 
-            not (False).
+            Boolean value denoting whether the tile centre is within the bounds
+            (True) or not (False).
         """
-        return tl.is_within_bounds(tile, self.ra_min, self.ra_max, self.dec_min, 
-                                   self.dec_max, compute_bounds_forcoords)
+        return tl.is_within_bounds(tile, self.ra_min, self.ra_max, 
+                                   self.dec_min, self.dec_max, 
+                                   compute_bounds_forcoords)
     
     
     def generate_random_tile(self):
-        """FWTiler wrapper for tiling.generate_random_tile(ra_min=0.0, ra_max=360.0,
-                                    dec_min=-90.0, dec_max=90.0, randomise_pa=False)
+        """FWTiler wrapper for:
+        tiling.generate_random_tile(ra_min=0.0, ra_max=360.0, dec_min=-90.0, 
+                                    dec_max=90.0, randomise_pa=False)
         
         Returns
         -------
@@ -682,59 +711,71 @@ class FWTiler(object):
     
     
     def generate_SH_tiling(self):
-        """FWTiler wrapper for tiling.generate_SH_tiling(tiling_file, randomise_seed=True, 
-                                    randomise_pa=False)
+        """FWTiler wrapper for:
+         tiling.generate_SH_tiling(tiling_file, randomise_seed=True, 
+                                   randomise_pa=False)
         
         Returns
         -------
         tile_list: list of TaipanTile objects
-            A list of TaipanTiles that have been generated from the Sloane-Harding tiling.
+            A list of TaipanTiles that have been generated from the 
+            Sloane-Harding tiling.
         """
         return tl.generate_SH_tiling(self.tiling_file, self.randomise_SH, 
                                      self.randomise_pa)
         
         
-    # ------------------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     # TaipanTile wrapper functions
-    # ------------------------------------------------------------------------------------   
-    def unpick_tile(self, tile, candidate_targets, standard_targets, guide_targets, 
-                    sky_targets):
-        """Wrapper function for TaipanTile.unpick_tile(...) to ensure tiling settings
-        are kept as internal as possible (i.e. exposing FWTiler attributes in as few
-        places as possible), and to aid in readability when unpicking a tile.
+    # -------------------------------------------------------------------------
+    def unpick_tile(self, tile, candidate_targets, standard_targets, 
+                    guide_targets, sky_targets):
+        """Wrapper function for TaipanTile.unpick_tile(...) to ensure tiling
+        settings are kept as internal as possible (i.e. exposing FWTiler 
+        attributes in as few places as possible), and to aid in readability 
+        when unpicking a tile.
         
         Parameters
         ----------
         tile: TaipanTile
             The TaipanTile object to unpick.
         candidate_targets: list of TaipanTarget objects
-            The potential science targets available for allocation to this TaipanTile.
+            The potential science targets available for allocation to this 
+            TaipanTile.
         standard_targets: list of TaipanTarget objects
-            The potential standard targets available for allocation to this TaipanTile.
+            The potential standard targets available for allocation to this 
+            TaipanTile.
         guide_targets: list of TaipanTarget objects
-            The potential guide targets available for allocation to this TaipanTile.  
+            The potential guide targets available for allocation to this 
+            TaipanTile.  
         sky_targets: list of TaipanTarget objects
-            The potential sky targets available for allocation to this TaipanTile.          
+            The potential sky targets available for allocation to this 
+            TaipanTile.          
         """
-        burn = tile.unpick_tile(candidate_targets, standard_targets, guide_targets,
-                                sky_targets, overwrite_existing=self.overwrite_existing, 
+        burn = tile.unpick_tile(candidate_targets, standard_targets, 
+                                guide_targets, sky_targets, 
+                                overwrite_existing=self.overwrite_existing, 
                                 check_tile_radius=self.check_tile_radius,
                                 recompute_difficulty=self.recompute_difficulty,
                                 method=self.tile_unpick_method, 
                                 combined_weight=self.combined_weight,
                                 sequential_ordering=self.sequential_ordering,
                                 rank_supplements=self.rank_supplements, 
-                                repick_after_complete=self.repick_after_complete,
-                                consider_removed_targets=self.consider_removed_targets, 
-                                allow_standard_targets=self.allow_standard_targets,
+                                repick_after_complete=
+                                self.repick_after_complete,
+                                consider_removed_targets=
+                                self.consider_removed_targets, 
+                                allow_standard_targets=
+                                self.allow_standard_targets,
                                 assign_sky_first=self.assign_sky_first,
                                 assign_sky_fibres=self.assign_sky_fibres)
         
         
     def calculate_tile_score(self, tile):
-        """Wrapper function for TaipanTile.calculate_tile_score(...) to ensure tiling 
-        settings are kept as internal as possible (i.e. exposing FWTiler attributes in as
-        few places as possible), and to aid in readability when calculating tile scores.
+        """Wrapper function for TaipanTile.calculate_tile_score(...) to ensure
+        tiling settings are kept as internal as possible (i.e. exposing FWTiler
+        attributes in as few places as possible), and to aid in readability 
+        when calculating tile scores.
         
         Parameters
         ----------
@@ -747,25 +788,27 @@ class FWTiler(object):
             The calculated score of the input TaipanTile.
         """
         return tile.calculate_tile_score(method=self.ranking_method,
-                                         disqualify_below_min=self.disqualify_below_min, 
+                                         disqualify_below_min=
+                                         self.disqualify_below_min, 
                                          combined_weight=self.combined_weight, 
                                          exp_base=self.exp_base)
 
         
-    # ------------------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     # FunnelWeb Tiling Helper Functions
-    # ------------------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     def get_targets_mag_range(self, candidate_targets, mag_range,  
                               mag_range_prioritise=None, last_range=False):
-        """Function to determine the candidate targets for a given magnitude range.
+        """Function to determine the candidate targets for a given magnitude 
+        range.
     
-        When using mag_range_prioritise to prioritise a subsection of the total magnitude 
-        bin, if a target is excluded (but would be included in a subsequent bin), it will 
-        only be observed if *low-priority*. This is to allow high priority (likely 
-        fainter) targets to be observed with a longer exposure time in the next magnitude 
-        bin (assuming bright-faint bin ordering). If the target is high-priority, and  
-        outside the priority mag range, but there are no fainter bins, it will be 
-        considered.
+        When using mag_range_prioritise to prioritise a subsection of the total
+        magnitude bin, if a target is excluded (but would be included in a 
+        subsequent bin), it will only be observed if *low-priority*. This is to
+        allow high priority (likely fainter) targets to be observed with a 
+        longer exposure time in the next magnitude bin (assuming bright-faint 
+        bin ordering). If the target is high-priority, and outside the priority
+        mag range, but there are no fainter bins, it will be considered.
     
         Parameters
         ----------
@@ -777,33 +820,38 @@ class FWTiler(object):
             Of form [L, U].
     
         mag_range_prioritise: list of floats, optional
-            Upper and lower bounds of the priority magnitude range within the mag bin
-            under consideration. If used, of form [L, U], else defaults to None. 
+            Upper and lower bounds of the priority magnitude range within the 
+            mag bin under consideration. If used, of form [L, U], else defaults
+            to None. 
     
         last_range: boolean
-            Indicates whether the magnitude range is the last bin under consideration, and
-            thus whether high priority targets should be considered.
+            Indicates whether the magnitude range is the last bin under 
+            consideration, and thus whether high priority targets should be 
+            considered.
         
         Returns
         -------
         candidate_targets_range: list of :class:`TaipanTarget`
-            The candidate targets that satisfy magnitude range and priority requirements.
+            The candidate targets that satisfy magnitude range and priority 
+            requirements.
         """ 
         print "Determining candidate targets for magnitude range...",
-        #Find the candidates in the correct magnitude range. If we are not in the faintest
-        #magnitude range, then we have to ignore high priority targets for now, as we'd
-        #rather them be observed with a long exposure time
+        # Find the candidates in the correct magnitude range. If we are not in
+        # the faintest magnitude range, then we have to ignore high priority 
+        # targets for now, as we'd rather them be observed with a long exposure
+        # time. Bright - B, Faint - F.
         if mag_range_prioritise:
             if not last_range:
                 candidate_targets_range = [t for t in candidate_targets 
-                    if ( (mag_range_prioritise[1] <= t.mag < mag_range[1]) and #faint
-                    (t.priority <= self.priority_normal) ) or
-                    ( (mag_range[0] <= t.mag < mag_range_prioritise[1]) )] #bright
+                    if ((mag_range_prioritise[1] <= t.mag < mag_range[1]) # F
+                    and (t.priority <= self.priority_normal) )
+                    or ((mag_range[0] <= t.mag < mag_range_prioritise[1]))] # B
             
-                # Increase the priority for targets in the priority magnitude range
+                # Increase priority for targets in priority magnitude range
                 for t in candidate_targets_range:
-                    if ( (mag_range_prioritise[0] <= t.mag < mag_range_prioritise[1]) and
-                        t.priority >= self.priority_normal):
+                    if ((mag_range_prioritise[0] <= t.mag
+                        < mag_range_prioritise[1])
+                        and t.priority >= self.priority_normal):
                         t.priority += self.prioritise_extra
         
             # In faintest bin, consider all targets
@@ -811,8 +859,9 @@ class FWTiler(object):
                 candidate_targets_range = [t for t in candidate_targets
                     if (mag_range[0] <= t.mag < mag_range[1])]
                 for t in candidate_targets_range:
-                    if ( (mag_range_prioritise[0] <= t.mag < mag_range_prioritise[1]) and
-                        t.priority == self.priority_normal):
+                    if ( (mag_range_prioritise[0] <= t.mag 
+                        < mag_range_prioritise[1])
+                        and t.priority == self.priority_normal):
                         t.priority += self.prioritise_extra
             
             print "done, # Targets=%i" % len(candidate_targets_range)      
@@ -834,8 +883,8 @@ class FWTiler(object):
         Returns
         -------
         standard_targets_range: list of :class:`TaipanTarget`
-            Subset of candidate_targets consisting of only the targets that satisfy the 
-            current magnitude range and priority requirements
+            Subset of candidate_targets consisting of only the targets that
+            satisfy the current magnitude range and priority requirements
         """
         print "Determining standard targets for magnitude range...",
         standard_targets_range = [t for t in standard_targets 
@@ -848,8 +897,8 @@ class FWTiler(object):
     def get_guides_mag_range(self, guide_targets, candidate_targets_range):
         """Function to select guide stars from within a given magnitude bin.
     
-        At present the only criteria for being considered a guide is to *not* be a 
-        candidate target for the range.
+        At present the only criteria for being considered a guide is to *not* 
+        be a candidate target for the range.
     
         TODO: Consider magnitude of guide stars.
     
@@ -859,8 +908,8 @@ class FWTiler(object):
             List of all available guide stars.
     
         candidate_targets_range: list of :class:`TaipanTarget`
-            Subset of candidate_targets consisting of only the targets that satisfy the 
-            current magnitude range and priority requirements
+            Subset of candidate_targets consisting of only the targets that
+            satisfy the current magnitude range and priority requirements
         
         Returns
         -------
@@ -868,16 +917,19 @@ class FWTiler(object):
             The guide targets that requirements.
         """
         print "Determining guide targets for magnitude range...",
-        # Find the guides that are not candidate targets only. These have to be copied, 
-        # because the same target will be a guide for one field and not a guide for 
-        # another field.
-        #non_candidate_guide_targets = [guide for guide in guide_targets 
-        #                               if guide not in candidate_targets_range]
+        # Find the guides that are not candidate targets only. These have to be
+        # copied, because the same target will be a guide for one field and not
+        # a guide for another field.
+        # non_candidate_guide_targets = [guide for guide in guide_targets 
+        #                              if guide not in candidate_targets_range]
         
-        # New set with elements in guide_targets but not candidate_targets_range
-        non_candidate_guide_targets = guide_targets.difference(candidate_targets_range)
+        # New set with elements in guide_targets but not 
+        # candidate_targets_range
+        non_candidate_guide_targets = guide_targets.difference(
+                                            candidate_targets_range)
         
-        non_candidate_guide_targets = copy.deepcopy(non_candidate_guide_targets)
+        non_candidate_guide_targets = copy.deepcopy(
+                                            non_candidate_guide_targets)
         
         # Set the flags appropriately
         for target in non_candidate_guide_targets:
@@ -890,8 +942,8 @@ class FWTiler(object):
  
  
     def calc_priority_targets(self, candidate_targets):
-        """Calculates the number of priority targets given the candidate targets and the 
-        completeness priority.
+        """Calculates the number of priority targets given the candidate 
+        targets and the completeness priority.
     
         Parameters
         ----------
@@ -901,32 +953,36 @@ class FWTiler(object):
         Returns
         -------
         n_priority_targets: int
-            Number of targets considered a priority for the given completeness_priority.
+            Number of targets considered a priority for the given 
+            completeness_priority.
         """
         # The number of priority targets is the number of targets above 
-        # completeness_priority. This includes some targets that are also standards.
+        # completeness_priority. This includes some targets that are also 
+        # standards.
         n_priority_targets = 0
         for target in candidate_targets:
             if target.priority >= self.completeness_priority:
                 n_priority_targets += 1
         #if n_priority_targets == 0:
-            #raise ValueError('Require some priority targets in each mag range!')
+        #raise ValueError('Require some priority targets in each mag range!')
         
         return n_priority_targets
         
         
     def log_tiling_progress(self, local_candidate_targets, n_priority_targets, 
-                            remaining_priority_targets, num_candidate_targets_range, 
-                            process_i, ra, dec, best_rank, num_assigned_priority, 
+                            remaining_priority_targets, 
+                            num_candidate_targets_range, 
+                            process_i, ra, dec, best_rank, 
+                            num_assigned_priority, 
                             num_assigned_candidates):
-        """Prints a summary of the current tiling progress and details of the most 
-        recently assigned tile.
+        """Prints a summary of the current tiling progress and details of the
+        most recently assigned tile.
         
         Parameters
         ----------
         local_candidate_targets: list of :class: `TaipanTarget`
-            The candidate targets within the bounds of the assigned tile (i.e. within a
-            single tile radii of the given ra and dec).
+            The candidate targets within the bounds of the assigned tile (i.e.
+            within a single tile radii of the given ra and dec).
         
         n_priority_target: int
             The total number of priority targets to allocate.
@@ -938,7 +994,8 @@ class FWTiler(object):
             The number of candidate targets remaining in the magnitude range.
         
         process_i: int
-            The process ID (0, 1, 2, 3, ...) of the the process that generated the tile.
+            The process ID (0, 1, 2, 3, ...) of the the process that generated
+            the tile.
         
         ra: float
             The right-ascension coordinate of the most recently assigned tile.
@@ -953,24 +1010,27 @@ class FWTiler(object):
             The number of priority targets assigned to the best tile.
             
         num_assigned_candidates: int
-            The number of candidates assigned to the tile (including priority targets).
+            The number of candidates assigned to the tile (including priority
+            targets).
         """
         nearby_priority = self.calc_priority_targets(local_candidate_targets)
         nearby_candidate = len(local_candidate_targets)
         
-        num_non_priority_candidates = num_assigned_candidates - num_assigned_priority
+        num_non_priority_candidates = (num_assigned_candidates
+                                       - num_assigned_priority)
         
         # Calculate the current completeness (cc)
         cc = (float(n_priority_targets - remaining_priority_targets)
               / float(n_priority_targets))
         print time.strftime("%H:%M:%S %d/%m/%y") + ";",
-        print "%5i / %5i P" % (remaining_priority_targets, n_priority_targets),                                          
+        print "%5i / %5i P" % (remaining_priority_targets, n_priority_targets),
         print "[%6i C ] --> %5.2f%%;" % (num_candidate_targets_range, 100*cc),
         print "assigned: P =%3i, C =%3i;" % (num_assigned_priority,
                                            num_non_priority_candidates),
         print "local: P =%4i, C =%5i;" % (nearby_priority, nearby_candidate),
         print "PID #%i, RA=%6.2f, DEC=%6.2f," % (process_i, ra, dec),
-        print "rank = %5i %s" % (best_rank, "T" if self.disqualify_below_min else "F")  
+        print "rank = %5i %s" % (best_rank, 
+                                 "T" if self.disqualify_below_min else "F")  
         
     
     def compute_ranking_dictionary(self, candidate_tiles):
@@ -979,59 +1039,66 @@ class FWTiler(object):
         Parameters
         ----------
         candidate_tiles: list of :class: `TaipanTile`
-            The list of filled candidate tiles covering the section of sky observed.
+            The list of filled candidate tiles covering the section of sky
+            observed.
         
         Returns
         -------
         ranking_list: OrderedDict
-            Dictionary with candidate_tiles as keys, and the corresponding tile score as 
+            Dictionary with candidate_tiles as keys, and the corresponding tile
+            score as 
             values.
         """
         # Compute the tile scores
-        tile_scores = [self.calculate_tile_score(tile) for tile in candidate_tiles]
+        tile_scores = [self.calculate_tile_score(tile) 
+                       for tile in candidate_tiles]
         
         # Pair tiles with their scores
         ranking_list = OrderedDict(zip(candidate_tiles, tile_scores))
         
         return ranking_list
                   
-    # ------------------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     # FunnelWeb Tiling Functions
-    # ------------------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     #@profile
-    def get_best_distant_tile(self, candidate_tiles, ranking_list, best_tiles=None, 
-                              n_radii=6):
-        """Selects the highest ranked tile from tile_list that is considered distant from
-        all tiles in best_tiles.
+    def get_best_distant_tile(self, candidate_tiles, ranking_list, 
+                              best_tiles=None, n_radii=6):
+        """Selects the highest ranked tile from tile_list that is considered
+        distant from all tiles in best_tiles.
         
         Todo: check to avoid indexing errors.
         
         Parameters
         ----------
         candidate_tiles: list of :class: `TaipanTile`
-            The list of filled candidate tiles covering the section of sky observed.
+            The list of filled candidate tiles covering the section of sky 
+            observed.
         
         ranking_list: list of floats
             List of tile scores corresponding to candidate_tiles.
             
         best_tiles: list of :class: `TaipanTile`
-            Already selected list of best tiles that any new tile must be considered
-            distant from.
+            Already selected list of best tiles that any new tile must be 
+            considered distant from.
             
         n_radii: int
-            The minimum separation between any selected tile and those in best_tiles.    
+            The minimum separation between any selected tile and those in 
+            best_tiles.    
             
         Returns
         -------
         best_tile: TaipanTile object or None
-            Either the highest ranked distant tile, or None if there are none to be found.
+            Either the highest ranked distant tile, or None if there are none 
+            to be found.
             
         best_rank: float
             Ranking of the selected best tile.
         """
         if best_tiles and len(best_tiles) > 0:
-            # While loop setup: sort indices of ranking list, initialise bool check/count
-            # ranking_list_i_sorted is sorted min-max so we index from the end (hence -1)
+            # While loop setup: sort indices of ranking list, initialise bool 
+            # check/count ranking_list_i_sorted is sorted min-max so we index 
+            # from the end (hence -1)
             ranking_list_i_sorted = np.argsort(ranking_list.values())
             found_best_distant_tile = False
             nth_max = -1
@@ -1040,45 +1107,52 @@ class FWTiler(object):
             while not found_best_distant_tile:
                 best_tile_i = ranking_list_i_sorted[nth_max]
                 
-                # This will fail if the order does not remain consistent between the 
-                # candidate_tiles list and the ranking list
-                assert candidate_tiles[best_tile_i] == ranking_list.keys()[best_tile_i]
+                # This will fail if the order does not remain consistent 
+                # between the  candidate_tiles list and the ranking list
+                assert (candidate_tiles[best_tile_i]
+                        == ranking_list.keys()[best_tile_i])
                 
                 candidate_ra = candidate_tiles[best_tile_i].ra
                 candidate_dec =  candidate_tiles[best_tile_i].dec
                 
-                nearby_best_tiles = tp.targets_in_range(candidate_ra, candidate_dec, 
+                nearby_best_tiles = tp.targets_in_range(candidate_ra, 
+                                                        candidate_dec, 
                                                         best_tiles, 
                                                         n_radii*tp.TILE_RADIUS)
                                                         
-                if len(nearby_best_tiles) == 0 and ranking_list.values()[best_tile_i] > 0:
-                    # Previous best tiles can be considered distant *and* the newly 
-                    # selected tile is not disqualified for not having the minimum number
-                    # of standards and guides --> select this tile
+                if (len(nearby_best_tiles) == 0 
+                    and ranking_list.values()[best_tile_i] > 0):
+                    # Previous best tiles can be considered distant *and* the
+                    # newly selected tile is not disqualified for not having 
+                    # the minimum number of standards and guides --> select 
+                    # this tile
                     found_best_distant_tile = True
                     
                 else:
-                    # The list is not empty, thus at least one of the other best tiles
-                    # can be considered close --> move on to the next highest ranked tile
-                    # Note: as long as we are never using an unreasonable number of 
-                    # processors (e.g. equal to a significant fraction of the total 
-                    # number of tiles on the sky) we should never reach the end of the 
-                    # ranking list for and thus do not need checks against it. It is 
-                    # however possible for us to reach the completion target without using
-                    # the best available remaining targets.
+                    # The list is not empty, thus at least one of the other 
+                    # best tiles can be considered close --> move on to the 
+                    # next highest ranked tile. Note: as long as we are never 
+                    # using an unreasonable number of processors (e.g. equal to
+                    # a significant fraction of the total number of tiles on 
+                    # the sky) we should never reach the end of the ranking 
+                    # list for and thus do not need checks against it. It is 
+                    # however possible for us to reach the completion target 
+                    # without using the best available remaining targets.
                     nth_max -= 1
                     
-                    # We have no exhausted ranking list and cannot find a suitable tile
+                    # We have no exhausted ranking list and cannot find a 
+                    # suitable tile
                     if np.abs(nth_max) > len(ranking_list_i_sorted):
                         return None, None
         
-        # Either we are just selecting the first best tile, or will only be selecting one
+        # Either we are just selecting the first best tile, or will only be 
+        # selecting one
         else:
             # Find the highest-ranked tile in the candidates_list
             best_tile_i = np.argmax(ranking_list.values())
         
-        # We now have the index of the best tile, remove it and its ranking from further
-        # consideration
+        # We now have the index of the best tile, remove it and its ranking 
+        # from further consideration
         best_tile = candidate_tiles.pop(best_tile_i) 
         best_rank = ranking_list.pop(best_tile)
         
@@ -1093,25 +1167,26 @@ class FWTiler(object):
         """Function to select the highest ranked tile for the final tiling, and 
         re-generate a replacement. 
     
-        Any science targets allocated to this tile are then removed from consideration
-        for future tiles, and any neighbouring tiles with now allocated targets are
-        repicked (reassigned).
+        Any science targets allocated to this tile are then removed from 
+        consideration for future tiles, and any neighbouring tiles with now 
+        allocated targets are repicked (reassigned).
     
         Parameters
         ----------
         best_tile: object of :class: `TaipanTile`
-            The highest ranked tile to be replaced and have its allocated targets removed
-            from further consideration.
+            The highest ranked tile to be replaced and have its allocated 
+            targets removed from further consideration.
         
         candidate_tiles: list of :class: `TaipanTile`
-            The list of filled candidate tiles covering the section of sky observed.
+            The list of filled candidate tiles covering the section of sky 
+            observed.
         
         candidate_targets: list of :class:`TaipanTarget`
             The entire list of candidate targets to consider.
         
         candidate_targets_range: list of :class:`TaipanTarget`
-            Subset of candidate_targets consisting of only the targets that satisfy the 
-            current magnitude range and priority requirements
+            Subset of candidate_targets consisting of only the targets that 
+            satisfy the current magnitude range and priority requirements
         
         Returns
         -------
@@ -1119,15 +1194,17 @@ class FWTiler(object):
             The number of priority targets allocated to best_tile.
             
         num_assigned_candidates: int
-            The number of candidates assigned to the tile (including priority targets).
+            The number of candidates assigned to the tile (including priority
+            targets).
         """
         # Record the ra and dec of the candidate for tile re-creation
         best_ra = best_tile.ra
         best_dec = best_tile.dec
 
         # Strip the now-assigned targets out of the candidate_targets and 
-        # candidate_targets_range lists, thus removing them from further consideration,
-        # then recalculate difficulties for affected remaning targets
+        # candidate_targets_range lists, thus removing them from further
+        # consideration, then recalculate difficulties for affected remaning 
+        # targets
         logging.info('Re-computing target list...')
         assigned_targets = best_tile.get_assigned_targets_science()
         
@@ -1138,19 +1215,20 @@ class FWTiler(object):
         reobserved_standards = []
         
         for target in assigned_targets:
-            # Note: when candidate_targets contains stars with higher than normal 
-            # *initial* priorities, it is possible for a star to be overlooked for
-            # consideration as a science target (observations being preferred in a 
-            # fainter magnitude bin for "high-priority" targets), but still 
-            # considered for selection as a standard target. As such is important
-            # to use candidate_targets_range, rather than simply candidate_targets 
-            # when dealing with assigned targets.
+            # Note: when candidate_targets contains stars with higher than
+            # normal *initial* priorities, it is possible for a star to be 
+            # overlooked for consideration as a science target (observations 
+            # being preferred in a  fainter magnitude bin for "high-priority" 
+            # targets), but still considered for selection as a standard 
+            # target. As such is important to use candidate_targets_range, 
+            # rather than simply candidate_targets  when dealing with assigned
+            # targets.
             if target in candidate_targets_range:
                 candidate_targets.remove(target)
                 candidate_targets_range.remove(target)
 
-                # Count the priority targets we've just assigned in the same way
-                # as they were originally counted
+                # Count the priority targets we've just assigned in the same
+                # way as they were originally counted
                 if target.priority >= self.completeness_priority:
                     num_assigned_priority += 1
         
@@ -1163,28 +1241,33 @@ class FWTiler(object):
                 logging.info('Re-allocating standard ' + str(target.idn) + 
                              ' that is also a science target.')
             else:
-                logging.warning('### WARNING: Assigned a target that is neither a ' + 
-                                'candidate target nor a standard!')
+                logging.warning('### WARNING: Assigned a target that is ' + 
+                                'neither a candidate target nor a standard!')
          
         if len(set(assigned_targets)) != len(assigned_targets):
             logging.warning('### WARNING: target duplication detected')
-        if len(candidate_targets_range) != (init_targets_len - len(assigned_targets) 
-                                            + len(reobserved_standards)):
-            logging.warning('### WARNING: Discrepancy found in target list reduction')
-            logging.warning('Best tile had %d targets; only %d removed from list' %
+        if (len(candidate_targets_range) 
+            != (init_targets_len - len(assigned_targets) 
+            + len(reobserved_standards))):
+            logging.warning('### WARNING: Discrepancy found in target list'
+                            'reduction')
+            logging.warning('Best tile had %d targets; only %d removed' %
                             (len(assigned_targets),
                              init_targets_len - len(candidate_targets)))
         if self.recompute_difficulty:
-            # Create a temporary list version of our candidate targets range set
+            # Create temporary list version of our candidate targets range set
             candidate_targets_range_list = list(candidate_targets_range)
             
             logging.info('Re-computing target difficulties...')
-            tp.compute_target_difficulties(tp.targets_in_range(best_ra, best_dec, 
+            tp.compute_target_difficulties(tp.targets_in_range(best_ra, 
+                                           best_dec, 
                                            candidate_targets_range_list,
-                                           tp.TILE_RADIUS + tp.FIBRE_EXCLUSION_DIAMETER))
+                                           (tp.TILE_RADIUS 
+                                           + tp.FIBRE_EXCLUSION_DIAMETER)))
 
         # Replace the removed tile in candidate_tiles
-        candidate_tiles.append(tp.TaipanTile(best_ra, best_dec, pa=self.gen_pa()))
+        candidate_tiles.append(tp.TaipanTile(best_ra, best_dec, 
+                               pa=self.gen_pa()))
     
         logging.info('Assigned tile at %3.1f, %2.1f' % (best_ra, best_dec))
     
@@ -1192,14 +1275,16 @@ class FWTiler(object):
 
     
     #@profile
-    def get_tile_neighbourhood(self, ra, dec, candidate_tiles, candidate_targets_range, 
-                               standard_targets_range, guide_targets_range, sky_targets,
+    def get_tile_neighbourhood(self, ra, dec, candidate_tiles, 
+                               candidate_targets_range, standard_targets_range,
+                               guide_targets_range, sky_targets,
                                n_tile_radii=2, n_target_radii=3, 
                                remove_tiles_from_master_list=True):
-        """Pop all tiles, targets, standards, and guides from the RA and DEC neighbourhood
-        into new lists (in the process removing them from the master lists). The master 
-        lists will be updated by reference. This function is required (presently) for the
-        multiprocessing code as Taipan object equivalence is not done at the object level.        
+        """Pop all tiles, targets, standards, and guides from the RA and DEC
+        neighbourhood into new lists (in the process removing them from the
+        master lists). The master lists will be updated by reference. This 
+        function is required (presently) for the multiprocessing code as 
+        Taipan object equivalence is not done at the object level.        
     
         Parameters
         ----------
@@ -1210,19 +1295,20 @@ class FWTiler(object):
             The DEC coordinate at the centre of the neighbourhood.
     
         candidate_tiles: list of :class: `TaipanTile`
-            The list of filled candidate tiles covering the section of sky observed.
+            The list of filled candidate tiles covering the section of sky 
+            observed.
         
         candidate_targets_range: list of :class:`TaipanTarget`
-            Subset of candidate_targets consisting of only the targets that satisfy the 
-            current magnitude range and priority requirements
+            Subset of candidate_targets consisting of only the targets that 
+            satisfy the current magnitude range and priority requirements
             
         standard_targets_range: list of :class:`TaipanTarget`
-            Subset of standard_targets consisting of only the standard targets that are 
-            within the current magnitude range.         
+            Subset of standard_targets consisting of only the standard targets
+            that are within the current magnitude range.         
             
         guide_targets_range: list of :class:`TaipanTarget`
-            Subset of guide_targets consisting of only the guide targets that are within 
-            the current magnitude range. 
+            Subset of guide_targets consisting of only the guide targets that
+            are within the current magnitude range. 
         
         sky_targets: list of :class:`TaipanTarget`
             List of sky targets to be considered
@@ -1234,10 +1320,11 @@ class FWTiler(object):
             The number of target radii out to consider for the neighbourhood.    
         
         remove_tiles_from_master_list: boolean
-            Whether to actually remove the neighbourhood from the master candidate_tile 
-            list. This should be set to true whenever running a multiprocessing 
-            implementation, as the *copies* of the tiles will be modified and returned, 
-            but can be set to false for single core implementations. Defaults to true.
+            Whether to actually remove the neighbourhood from the master
+            candidate_tile list. This should be set to true whenever running a
+            multiprocessing implementation, as the *copies* of the tiles will
+            be modified and returned, but can be set to false for single core
+            implementations. Defaults to true.
     
         Returns
         -------
@@ -1256,7 +1343,8 @@ class FWTiler(object):
         nearby_sky: list of :class:`TaipanTarget`
             The list of nearby sky.
         """    
-        # Create lists of neighbouring tiles, and candidate science/standard/guides/sky
+        # Create lists of neighbouring tiles, and candidate 
+        # science/standard/guides/sky targets
         nearby_tiles = tp.targets_in_range(ra, dec, candidate_tiles, 
                                            n_tile_radii*tp.TILE_RADIUS) 
    
@@ -1273,43 +1361,46 @@ class FWTiler(object):
                                             
         nearby_sky = tp.targets_in_range(ra, dec, sky_targets, 
                                          n_target_radii*tp.TILE_RADIUS,
-                                         tree=self.sky_tree)                                      
+                                         tree=self.sky_tree)
     
-        # Remove candidate tiles from the master list - these need to be updated with the
-        # copies that come back from the other processes. No need to do the same for
-        # targets, standards, or guides.
+        # Remove candidate tiles from the master list - these need to be 
+        # updated with the copies that come back from the other processes. 
+        # No need to do the same for targets, standards, or guides.
         if remove_tiles_from_master_list:
             for tile in nearby_tiles:
                 candidate_tiles.remove(tile) 
 
         # All done, return lists of nearby tiles/targets/standards/guides
-        return nearby_tiles, nearby_targets, nearby_standards, nearby_guides, nearby_sky
+        return nearby_tiles, nearby_targets, nearby_standards, nearby_guides,\
+               nearby_sky
     
     
     #@profile
-    def greedy_tile_sc(self, candidate_tiles, candidate_targets, candidate_targets_range, 
-                       standard_targets_range, guide_targets_range, sky_targets, 
-                       ranking_list, n_priority_targets, remaining_priority_targets):
+    def greedy_tile_sc(self, candidate_tiles, candidate_targets, 
+                       candidate_targets_range, standard_targets_range, 
+                       guide_targets_range, sky_targets, ranking_list, 
+                       n_priority_targets, remaining_priority_targets):
         """
         Parameters
         ----------
         candidate_tiles: list of :class: `TaipanTile`
-            The list of filled candidate tiles covering the section of sky observed.
+            The list of filled candidate tiles covering the section of sky 
+            observed.
             
         candidate_targets: list of :class:`TaipanTarget`
             The entire list of candidate targets to consider.
         
         candidate_targets_range: list of :class:`TaipanTarget`
-            Subset of candidate_targets consisting of only the targets that satisfy the 
-            current magnitude range and priority requirements
+            Subset of candidate_targets consisting of only the targets that 
+            satisfy the current magnitude range and priority requirements
     
         standard_targets_range: list of :class:`TaipanTarget`
-            Subset of standard_targets consisting of only the standard targets that are 
-            within the current magnitude range. 
+            Subset of standard_targets consisting of only the standard targets
+            that are within the current magnitude range. 
         
         guide_targets_range: list of :class:`TaipanTarget`
-            Subset of guide_targets consisting of only the guide targets that are within 
-            the current magnitude range. 
+            Subset of guide_targets consisting of only the guide targets that
+            are within the current magnitude range. 
             
         sky_targets: list of :class:`TaipanTarget`
             Sky targets to be considered. 
@@ -1326,84 +1417,100 @@ class FWTiler(object):
         Returns
         -------
         best_tile: TaipanTile
-            The selected best candidate tile, with targets now considered allocated.
+            The selected best candidate tile, with targets now considered 
+            allocated.
             
         remaining_priority_targets: int
             The updated number of priority targets remaining to be allocated.
         """
         # Find best tile
-        best_tile, best_rank = self.get_best_distant_tile(candidate_tiles, ranking_list)                                                 
+        best_tile, best_rank = self.get_best_distant_tile(candidate_tiles, 
+                                                          ranking_list)
         
-        # Replace the best tile and remove its assigned targets from further consideration
-        num_assigned_priority, num_assigned_candidates = self.replace_best_tile(
-                                                           best_tile, candidate_tiles, 
-                                                           candidate_targets, 
-                                                           candidate_targets_range)
+        # Replace the best tile and remove its assigned targets from further 
+        # consideration
+        num_assigned_priority, num_assigned_candidates = \
+            self.replace_best_tile(best_tile, candidate_tiles, 
+                                   candidate_targets, candidate_targets_range)
         
         # Create a temporary list version of our candidate targets range set
         candidate_targets_range_list = list(candidate_targets_range)
         
-        # Update the count for remaining priority targets                                            
+        # Update the count for remaining priority targets 
         remaining_priority_targets -= num_assigned_priority
         
-        # Implement tiered approach and get neighbourhood (tiles/targets/standards/guides)
-        # of the central tile. By doing this, further calls to tp.targets_in_range from
-        # within repick_within_range do not have to use the full lists (which might be 
-        # millions of targets long), but can instead search the neighbourhood which will 
-        # by definition contain fewer targets. Make sure not to remove the tiles from the
-        # master candidate_tiles list.
-        nearby_tiles, nearby_targets, nearby_standards, nearby_guides, nearby_sky = \
-                self.get_tile_neighbourhood(best_tile.ra, best_tile.dec, 
-                                            candidate_tiles, candidate_targets_range_list,  
-                                            standard_targets_range, guide_targets_range,  
-                                            sky_targets, n_tile_radii=2, n_target_radii=3,
-                                            remove_tiles_from_master_list=False)  
+        # Implement tiered approach and get neighbourhood (tiles/targets/
+        # standards/guides) of the central tile. By doing this, further calls
+        # to tp.targets_in_range from within repick_within_range do not have to
+        # use the full lists (which might be millions of targets long), but can
+        # instead search the neighbourhood which will by definition contain
+        # fewer targets. Make sure not to remove the tiles from the master 
+        # candidate_tiles list.
+        nearby_tiles, nearby_targets, nearby_standards, nearby_guides, \
+            nearby_sky = self.get_tile_neighbourhood(best_tile.ra, 
+                                                 best_tile.dec, 
+                                                 candidate_tiles, 
+                                                 candidate_targets_range_list,  
+                                                 standard_targets_range, 
+                                                 guide_targets_range,  
+                                                 sky_targets, n_tile_radii=2, 
+                                                 n_target_radii=3,
+                                                 remove_tiles_from_master_list
+                                                 =False)  
         
-        # All affected tiles have been unpicked, and best_tile has been replaced. Now 
-        # update the ranking list accordingly (modifying only the affected elements 
+        # All affected tiles have been unpicked, and best_tile has been
+        # replaced. Now update the ranking list accordingly (modifying only the
+        # affected elements 
         # rather than entirely recomputing it)    
         for tile in nearby_tiles:
             ranking_list[tile] = self.calculate_tile_score(tile)
         
         # Create an update on the tiling progress
-        local_candidate_targets = tp.targets_in_range(best_tile.ra, best_tile.dec, 
-                                                      nearby_targets, 1*tp.TILE_RADIUS)
+        local_candidate_targets = tp.targets_in_range(best_tile.ra, 
+                                                      best_tile.dec, 
+                                                      nearby_targets, 
+                                                      1*tp.TILE_RADIUS)
 
         self.log_tiling_progress(local_candidate_targets, n_priority_targets, 
-                                 remaining_priority_targets, len(candidate_targets_range), 
+                                 remaining_priority_targets, 
+                                 len(candidate_targets_range), 
                                  0, best_tile.ra, best_tile.dec, best_rank, 
-                                 num_assigned_priority, num_assigned_candidates)
+                                 num_assigned_priority, 
+                                 num_assigned_candidates)
         
         # Repick all tiles within a given radius of the selected tile
-        repick_within_radius(best_tile, nearby_tiles, nearby_targets, nearby_standards, 
-                             nearby_guides, nearby_sky, self.unpick_settings)
+        repick_within_radius(best_tile, nearby_tiles, nearby_targets, 
+                             nearby_standards, nearby_guides, nearby_sky, 
+                             self.unpick_settings)
                          
         return best_tile, remaining_priority_targets
         
     #@profile    
-    def greedy_tile_mc(self, candidate_tiles, candidate_targets, candidate_targets_range, 
-                       standard_targets_range, guide_targets_range, ranking_list, 
-                       n_priority_targets, remaining_priority_targets):
+    def greedy_tile_mc(self, candidate_tiles, candidate_targets, 
+                       candidate_targets_range, standard_targets_range, 
+                       guide_targets_range, ranking_list, n_priority_targets, 
+                       remaining_priority_targets):
         """
         Parameters
         ----------
         candidate_tiles: list of :class: `TaipanTile`
-            The list of filled candidate tiles covering the section of sky observed.
+            The list of filled candidate tiles covering the section of sky 
+            observed.
             
         candidate_targets: list of :class:`TaipanTarget`
             The entire list of candidate targets to consider.
         
         candidate_targets_range: list of :class:`TaipanTarget`
-            Subset of candidate_targets consisting of only the targets that satisfy the 
-            current magnitude range and priority requirements
+            Subset of candidate_targets consisting of only the targets that 
+            satisfy the current magnitude range and priority requirements
     
         standard_targets_range: list of :class:`TaipanTarget`
-            Subset of standard_targets consisting of only the standard targets that are 
-            within the current magnitude range. 
+            Subset of standard_targets consisting of only the standard targets
+            that are within the current magnitude range. 
         
         guide_targets_range: list of :class:`TaipanTarget`
-            Subset of guide_targets consisting of only the guide targets that are within 
-            the current magnitude range. 
+            Subset of guide_targets consisting of only the guide targets that 
+            are within the current magnitude range. 
         
         ranking_list: list of int
             List of tile scores with indices corresponding to candidate_tiles.
@@ -1417,8 +1524,8 @@ class FWTiler(object):
         Returns
         -------
         best_tiles: list of :class: `TaipanTile`
-            List of the n selected best candidate tiles, with targets now considered
-            allocated.
+            List of the n selected best candidate tiles, with targets now 
+            considered allocated.
             
         remaining_priority_targets: int
             The updated number of priority targets remaining to be allocated.
@@ -1435,51 +1542,54 @@ class FWTiler(object):
         
         num_candidate_targets_range = len(candidate_targets_range)
     
-        # This loop builds up the dictionary consisting of the best tile and its
-        # neighbouring tiles/targets/standards/guides until it has length equal to
-        # the # of cores available. Once built, each entry in the dictionary is
-        # sent off to a different process to have the neighbourhood repicked.
-        # TODO: Have contingency if for some reason we cannot select enough tiles
+        # This loop builds up the dictionary consisting of the best tile and 
+        # its neighbouring tiles/targets/standards/guides until it has length 
+        # equal to the # of cores available. Once built, each entry in the 
+        # dictionary is sent off to a different process to have the 
+        # neighbourhood repicked.
+        # TODO: Contingency if for some reason we cannot select enough tiles
         for process_i in xrange(0, self.n_cores):
             # Find best tile that is >=6 tiles away from other best tiles
             # If best_tiles.keys() is empty, the best tile will be returned
-            nth_best_tile, best_rank = self.get_best_distant_tile(candidate_tiles,
-                                                                  ranking_list,
-                                                                  best_tiles.keys(), 
-                                                                  n_radii=6)
+            nth_best_tile, best_rank = self.get_best_distant_tile(
+                                                candidate_tiles, ranking_list,
+                                                best_tiles.keys(), n_radii=6)
             
             # We were unsuccessful in finding tiles up to n_cores, proceed with
             # what we have and break out of the for loop
-            # Note: assumption is that we will never reach this point on the first
-            # iteration of this loop - a situation that could only arise if *all* tile
-            # scores are zero.
+            # Note: assumption is that we will never reach this point on the 
+            # first iteration of this loop - a situation that could only arise 
+            # if *all* tile scores are zero.
             if not nth_best_tile:
-                logging.info("nth_best_tile is None, aborting filling to n_cores")
+                logging.info("nth_best_tile=None, aborting filling to n_cores")
                 break
                 
                 # Should never get here, but just in case
                 if process_i == 0:
-                    raise Exception("Greedy MC failed without selecting a tile!")
+                    raise Exception("Greedy MC failed without tile selection!")
             
-            # Replace the best tile and remove its assigned targets from further
-            # consideration
-            num_assigned_priority, num_assigned_candidates = self.replace_best_tile(
-                                                               nth_best_tile, 
-                                                               candidate_tiles, 
-                                                               candidate_targets, 
-                                                               candidate_targets_range)
+            # Replace the best tile and remove its assigned targets from 
+            # further consideration
+            n_assigned_pri, n_assigned_cand = self.replace_best_tile(
+                                                    nth_best_tile, 
+                                                    candidate_tiles, 
+                                                    candidate_targets, 
+                                                    candidate_targets_range)
                                                     
-            # Update the count for remaining priority targets                                            
-            remaining_priority_targets -= num_assigned_priority                                        
+            # Update the count for remaining priority targets
+            remaining_priority_targets -= n_assigned_pri
             
-            # Create a temporary list version of our candidate targets range set
+            # Create temporary list version of our candidate targets range set
             candidate_targets_range_list = list(candidate_targets_range)
             
-            # Create lists of all neighbouring affected tiles/targets/standards/guides
+            # Create lists of all neighbouring affected tiles/targets/standards
+            # /guides/sky targets
             nearby_tiles, nearby_targets, nearby_standards, nearby_guides = \
-                self.get_tile_neighbourhood(nth_best_tile.ra, nth_best_tile.dec, 
-                                            candidate_tiles, candidate_targets_range_list,  
-                                            standard_targets_range, guide_targets_range,  
+                self.get_tile_neighbourhood(nth_best_tile.ra, 
+                                            nth_best_tile.dec, candidate_tiles, 
+                                            candidate_targets_range_list,  
+                                            standard_targets_range, 
+                                            guide_targets_range, 
                                             n_tile_radii=2, n_target_radii=3)  
             
             # Create an update on the tiling progress
@@ -1488,61 +1598,76 @@ class FWTiler(object):
                                                           nearby_targets, 
                                                           1*tp.TILE_RADIUS)
 
-            self.log_tiling_progress(local_candidate_targets, n_priority_targets, 
+            self.log_tiling_progress(local_candidate_targets, 
+                                     n_priority_targets, 
                                      remaining_priority_targets, 
                                      len(candidate_targets_range), process_i, 
-                                     nth_best_tile.ra, nth_best_tile.dec, best_rank,
-                                     num_assigned_priority, num_assigned_candidates)
+                                     nth_best_tile.ra, nth_best_tile.dec, 
+                                     best_rank, n_assigned_pri, 
+                                     n_assigned_cand)
                                                                   
             # Add an entry to the dictionary to be sent to the subprocess
-            if self.backend == "multiprocessing" or self.backend == "threading":
-                best_tiles[nth_best_tile] = (nearby_tiles[:], nearby_targets[:],
-                                             nearby_standards[:], nearby_guides[:])
+            if (self.backend == "multiprocessing"
+                or self.backend == "threading"):
+                best_tiles[nth_best_tile] = (nearby_tiles[:], 
+                                             nearby_targets[:],
+                                             nearby_standards[:], 
+                                             nearby_guides[:])
+                                             
             elif self.backend == "pool":
                 # Instead add the neighbourhood information to the manager
                 tile_neighbourhood.append((nth_best_tile, nearby_targets, 
-                                           nearby_standards, nearby_guides, nearby_tiles))
+                                           nearby_standards, nearby_guides, 
+                                           nearby_tiles))
                                            
                 # But still add the best tiles to the dictionary
                 best_tiles[nth_best_tile] = process_i
             
             else:
-                raise Exception("Warning: Unidentified backend: " + self.backend) 
+                raise Exception("Warning: Unidentified backend: " 
+                                + self.backend) 
             
             import pdb
             pdb.set_trace()
             
-            # While we have the handles, remove any neighbourhood tiles from the ranking
-            # list as we will need to recompute the rankings after repick_within_radius  
+            # While we have the handles, remove any neighbourhood tiles from 
+            # the ranking list as we will need to recompute the rankings after 
+            # repick_within_radius  
             for tile in nearby_tiles:
-                # Only pop those tiles in the list, and not the new replacement tile
-                if tile.ra != nth_best_tile.ra and tile.dec != nth_best_tile.dec:
+                # Only pop those tiles in the list, and not the new replacement
+                # tile
+                if (tile.ra != nth_best_tile.ra 
+                    and tile.dec != nth_best_tile.dec):
                     try:
                         ranking_list.pop(tile)
                     except:
                         import pdb
                         pdb.set_trace()
             # Recalculate the ranking list to account for the now missing items
-            #ranking_list = [self.calculate_tile_score(tile) for tile in candidate_tiles] 
+            #ranking_list = [self.calculate_tile_score(tile) 
+            #                for tile in candidate_tiles] 
             
             # If max of the ranking_list is now 0, abort filling up to n_cores
-            # Note: by aborting here, any already created processes (at least one) will be
-            # run, but we won't create any more. Should not matter what the status of 
-            # self.disqualify_below_min is - don't want any targets with a score of 0.
+            # Note: by aborting here, any already created processes (at least 
+            # one) will be run, but we won't create any more. Should not matter
+            # what the status of self.disqualify_below_min is - don't want any
+            # targets with a score of 0.
             if max(ranking_list.values()) < 0.05:
-                logging.info("max(ranking_list) < 0.05, abort filling to n_cores")
+                logging.info("max(ranking_list) < 0.05, abort filling to" 
+                             "n_cores")
                 break
         
         if self.backend == "multiprocessing" or self.backend == "threading":
             # Dictionary is constructed, now perform parallel repick
             n_processes = len(best_tiles.keys())
             results = Parallel(n_jobs=n_processes, backend=self.backend)(
-                         delayed(repick_within_radius)(tile, best_tiles[tile][0],
+                         delayed(repick_within_radius)(tile, 
+                                                       best_tiles[tile][0],
                                                        best_tiles[tile][1],
                                                        best_tiles[tile][2],
                                                        best_tiles[tile][3],
                                                        self.unpick_settings)
-                                                 for tile in best_tiles.keys())  
+                                                 for tile in best_tiles.keys())
     
             # Done, now add back in the nearby candidate tiles
             for updated_nearby_candidate_tiles in results:
@@ -1554,9 +1679,10 @@ class FWTiler(object):
             n_processes = len(tile_neighbourhood)
             pool = mp.Pool(processes=n_processes)
 
-            pool.map(repick_within_radius_pool, [(process_i, tile_neighbourhood,  
-                                             repicked_tiles, self.unpick_settings)
-                                           for process_i in xrange(0, n_processes)])
+            pool.map(repick_within_radius_pool, 
+                     [(process_i, tile_neighbourhood, repicked_tiles, 
+                      self.unpick_settings)
+                      for process_i in xrange(0, n_processes)])
             pool.close()
             pool.join()
             
@@ -1564,9 +1690,10 @@ class FWTiler(object):
             for neighbourhood in repicked_tiles:
                 candidate_tiles.extend(neighbourhood)
                 
-                # Compute the scores and update the ranking list for all neighbourhood 
-                # tiles. Unlike the SC case, these will be copies, hence we need to remove
-                # and re-add after returning from running in parallel.
+                # Compute the scores and update the ranking list for all 
+                # neighbourhood tiles. Unlike the SC case, these will be 
+                # copies, hence we need to remove and re-add after returning
+                # from running in parallel.
                 for tile in neighbourhood:
                     ranking_list[tile] = self.calculate_tile_score(tile)
            
@@ -1575,29 +1702,33 @@ class FWTiler(object):
 
     #@profile
     def greedy_tile_sky(self, candidate_targets, candidate_targets_range,  
-                        standard_targets_range, guide_targets_range, sky_targets, 
-                        candidate_tiles, mag_range):
-        """Function to perform the greedy tiling algorithm given targets, standards, 
-        guides, and a selection of tiles.
+                        standard_targets_range, guide_targets_range, 
+                        sky_targets, candidate_tiles, mag_range):
+        """Function to perform the greedy tiling algorithm given targets, 
+        standards, guides, and a selection of tiles.
         
-        Depending on the value FWTiler.n_cores, this function will either employ a non-
-        multiprocessing, or multiprocessing variant of the greedy tiling algorithm. The
-        algorithm is described as follows:
-            A) While not at the completeness target, and there are still valid tiles:
+        Depending on the value FWTiler.n_cores, this function will either 
+        employ a non-multiprocessing, or multiprocessing variant of the greedy
+        tiling algorithm. The algorithm is described as follows:
+            A) While not at the completeness target, and there are still valid
+               tiles:
                 1) Do the following up to the number of available cores:
-                    - Select the Nth best tile, separated by more than 6 tile radii on-
-                      sky from any/all other best tiles, and add to final tiling. 
-                    - Replace the best tile and update the remaining number of priority
-                      targets.
-                    - Collate all affected tiles within a 2 tile radii of the best tile,
-                      as well as those targets within 3 tile radii (popped into
-                      separate listd as to only consider relevant targets). 
-                2) Repick the affected tiles in a parallel environment, one process for 
-                   each best tile and set of associated tiles/targets.
-                3) Now back in the standard environment, reassemble the separate lists 
-                   passed to each sub-process, and update the master candidate lists 
-                   accordingly.
-            B) Tiling complete, return the resulting set of tiles.                   
+                    - Select the Nth best tile, separated by more than 6 tile 
+                      radii on-sky from any/all other best tiles, and add to 
+                      final tiling. 
+                    - Replace the best tile and update the remaining number of 
+                      priority targets.
+                    - Collate all affected tiles within a 2 tile radii of the 
+                      best tile, as well as those targets within 3 tile radii 
+                      (popped into separate listd as to only consider relevant 
+                      targets). 
+                2) Repick the affected tiles in a parallel environment, one 
+                   process for each best tile and set of associated tiles/
+                   targets.
+                3) Now back in the standard environment, reassemble the 
+                   separate lists passed to each sub-process, and update the 
+                   master candidate lists accordingly.
+            B) Tiling complete, return the resulting set of tiles.
     
         Parameters
         ----------
@@ -1605,22 +1736,23 @@ class FWTiler(object):
             The entire list of candidate targets to consider.
         
         candidate_targets_range: list of :class:`TaipanTarget`
-            Subset of candidate_targets consisting of only the targets that satisfy the 
-            current magnitude range and priority requirements
+            Subset of candidate_targets consisting of only the targets that 
+            satisfy the current magnitude range and priority requirements
     
         standard_targets_range: list of :class:`TaipanTarget`
-            Subset of standard_targets consisting of only the standard targets that are 
-            within the current magnitude range. 
+            Subset of standard_targets consisting of only the standard targets 
+            that are within the current magnitude range. 
         
         guide_targets_range: list of :class:`TaipanTarget`
-            Subset of guide_targets consisting of only the guide targets that are within 
-            the current magnitude range. 
+            Subset of guide_targets consisting of only the guide targets that 
+            are within the current magnitude range. 
         
         sky_targets: list of :class:`TaipanTarget`
             All sky_targets to be considered.
                 
         candidate_tiles: list of :class: `TaipanTile`
-            The list of filled candidate tiles covering the section of sky observed.
+            The list of filled candidate tiles covering the section of sky 
+            observed.
             
         mag_range: [min_mag, max_mag]
             List of the bounds of the current magnitude range.
@@ -1628,8 +1760,8 @@ class FWTiler(object):
         Returns
         -------
         tile_list: list of :class: `TaipanTile`
-            The set of tiles meeting the completeness requirement for the provided set of
-            targets.
+            The set of tiles meeting the completeness requirement for the 
+            provided set of targets.
         """
         # Create a temporary list version of our candidate targets range set
         candidate_targets_range_list = list(candidate_targets_range)
@@ -1644,9 +1776,10 @@ class FWTiler(object):
             delta = finish - start
             print ("done in %d:%02.1f") % (delta/60, delta % 60.)
         
-        # Create the initial unpick of every tile, making sure to only pass it those
-        # targets that it can actually tile. Duplicates are not a concern at this stage,
-        # nor are updating the target difficulties - both will be dealt with later.
+        # Create the initial unpick of every tile, making sure to only pass it
+        # those targets that it can actually tile. Duplicates are not a concern
+        # at this stage, nor are updating the target difficulties - both will 
+        # be dealt with later.
         logging.info('Creating initial tile unpicks...')
         print "Performing initial global tile unpicks...",
         start = time.time()
@@ -1654,33 +1787,38 @@ class FWTiler(object):
         # Create temporary version of candidate_tiles
         temp_candidate_tiles = candidate_tiles[:]
         
-        # Pre-generate the KD tree for the *master* standard and guide lists. These will
-        # never change, and thus be stored for the duration of the tiling run. The target
-        # list however will change as we remove targets as they are observed. Thus we
-        # cannot ever stor a *master* KD Tree for the targets, but we can generate 
-        # temporary ones each time we are within a neighbourhood.
+        # Pre-generate the KD tree for the *master* standard and guide lists. 
+        # These will never change, and thus be stored for the duration of the 
+        # tiling run. The target list however will change as we remove targets 
+        # as they are observed. Thus we cannot ever stor a *master* KD Tree for
+        # the targets, but we can generate temporary ones each time we are 
+        # within a neighbourhood.
         self.standard_tree = precompute_kd_tree(standard_targets_range)
         self.guide_tree = precompute_kd_tree(guide_targets_range)
         self.sky_tree = precompute_kd_tree(sky_targets)
         
         while len(temp_candidate_tiles) > 0:  
-            # Get the neighbourhood of an arbitrary tile, unpick the neighbours, then
-            # remove all from the set. Doing the initial unpicking this way has the 
-            # potential to be 7x faster as we make fewer calls to tp.targets_in_range with
-            # the full length target/standard/guide lists.
+            # Get the neighbourhood of an arbitrary tile, unpick the 
+            # neighbours, then remove all from the set. Doing the initial 
+            # unpicking this way has the potential to be 7x faster as we make 
+            # fewer calls to tp.targets_in_range with the full length target/
+            # standard/guide lists.
             central_tile = temp_candidate_tiles[-1]
             
-            # Get the neighbourhood tiles, targets, standards, and guides. The selected
-            # tiles are removed from the list
-            nearby_tiles, nearby_targets, nearby_standards, nearby_guides, nearby_sky = \
-                self.get_tile_neighbourhood(central_tile.ra, central_tile.dec, 
-                                            temp_candidate_tiles, 
-                                            candidate_targets_range_list,  
-                                            standard_targets_range, guide_targets_range, 
-                                            sky_targets, n_tile_radii=2, n_target_radii=3) 
+            # Get the neighbourhood tiles, targets, standards, and guides. The 
+            # selected tiles are removed from the list
+            nearby_tiles, nearby_targets, nearby_standards, nearby_guides, \
+                nearby_sky = self.get_tile_neighbourhood(central_tile.ra, 
+                                                central_tile.dec, 
+                                                temp_candidate_tiles, 
+                                                candidate_targets_range_list,  
+                                                standard_targets_range, 
+                                                guide_targets_range, 
+                                                sky_targets, n_tile_radii=2, 
+                                                n_target_radii=3) 
             
-            # Pre-generate the KD tree for the nearby lists of targets. These will not
-            # change for the duration of the following loop
+            # Pre-generate the KD tree for the nearby lists of targets. These 
+            # will not change for the duration of the following loop
             nearby_target_tree = precompute_kd_tree(nearby_targets)
             nearby_standard_tree = precompute_kd_tree(nearby_standards)
             nearby_guide_tree = precompute_kd_tree(nearby_guides)
@@ -1689,16 +1827,21 @@ class FWTiler(object):
             for tile in nearby_tiles:
                 # Unpick each tile in the neighbourhood
                 self.unpick_tile(tile, 
-                                 tp.targets_in_range(tile.ra, tile.dec, nearby_targets, 
+                                 tp.targets_in_range(tile.ra, tile.dec, 
+                                                     nearby_targets, 
                                                      1*tp.TILE_RADIUS,
                                                      tree=nearby_target_tree), 
-                                 tp.targets_in_range(tile.ra, tile.dec, nearby_standards, 
+                                 tp.targets_in_range(tile.ra, tile.dec, 
+                                                     nearby_standards, 
                                                      1*tp.TILE_RADIUS,
-                                                     tree=nearby_standard_tree), 
-                                 tp.targets_in_range(tile.ra, tile.dec, nearby_guides, 
+                                                     tree=
+                                                     nearby_standard_tree), 
+                                 tp.targets_in_range(tile.ra, tile.dec, 
+                                                     nearby_guides, 
                                                      1*tp.TILE_RADIUS,
                                                      tree=nearby_guide_tree),
-                                 tp.targets_in_range(tile.ra, tile.dec, nearby_sky, 
+                                 tp.targets_in_range(tile.ra, tile.dec, 
+                                                     nearby_sky, 
                                                      1*tp.TILE_RADIUS,
                                                      tree=nearby_sky_tree))
         
@@ -1710,32 +1853,33 @@ class FWTiler(object):
         ranking_list = self.compute_ranking_dictionary(candidate_tiles)     
                     
         # Calculate priority targets
-        n_priority_targets = self.calc_priority_targets(candidate_targets_range_list)
+        n_priority_targets = self.calc_priority_targets(
+                                    candidate_targets_range_list)
         
-        remaining_priority_targets = n_priority_targets
+        remaining_pri_tgts = n_priority_targets
 
-        # While we are below our completeness criteria AND the highest-ranked tile is not
-        # empty, perform the greedy algorithm
+        # While we are below our completeness criteria AND the highest-ranked 
+        # tile is not empty, perform the greedy algorithm
         logging.info('Starting greedy/Funnelweb tiling allocation...')        
         tile_list = []
         tile_i = 0
         
         # Note: 0.05 is a simple proxy for max > 0
-        while ((float(n_priority_targets - remaining_priority_targets) 
-               / float(n_priority_targets)) < self.completeness_target) and \
-               (max(ranking_list.values()) > 0.05): 
+        while (((float(n_priority_targets - remaining_pri_tgts) 
+               / float(n_priority_targets)) < self.completeness_target) 
+               and (max(ranking_list.values()) > 0.05)): 
             # Single core
             if self.n_cores == 0:
-                best_tile, remaining_priority_targets = self.greedy_tile_sc(
-                                                            candidate_tiles, 
-                                                            candidate_targets, 
-                                                            candidate_targets_range, 
-                                                            standard_targets_range, 
-                                                            guide_targets_range, 
-                                                            sky_targets,
-                                                            ranking_list, 
-                                                            n_priority_targets, 
-                                                            remaining_priority_targets)                                            
+                best_tile, remaining_pri_tgts = self.greedy_tile_sc(
+                                                    candidate_tiles, 
+                                                    candidate_targets, 
+                                                    candidate_targets_range, 
+                                                    standard_targets_range, 
+                                                    guide_targets_range, 
+                                                    sky_targets,
+                                                    ranking_list, 
+                                                    n_priority_targets, 
+                                                    remaining_pri_tgts)
             
                 # Add the magnitude range information
                 best_tile.mag_min = mag_range[0]
@@ -1746,25 +1890,23 @@ class FWTiler(object):
                 
             # Multicore    
             else:
-                best_tiles, remaining_priority_targets = self.greedy_tile_mc(
-                                                            candidate_tiles, 
-                                                            candidate_targets, 
-                                                            candidate_targets_range, 
-                                                            standard_targets_range, 
-                                                            guide_targets_range, 
-                                                            ranking_list, 
-                                                            n_priority_targets, 
-                                                            remaining_priority_targets) 
+                best_tiles, remaining_pri_tgts = self.greedy_tile_mc(
+                                                    candidate_tiles, 
+                                                    candidate_targets, 
+                                                    candidate_targets_range, 
+                                                    standard_targets_range, 
+                                                    guide_targets_range, 
+                                                    ranking_list, 
+                                                    n_priority_targets, 
+                                                    remaining_pri_tgts) 
                 
-                # Add the n best tiles to the set of selected tiles, and assign mag info
+                # Add the n best tiles to the set of selected tiles, and assign
+                # mag info
                 for nth_best_tile in best_tiles:
                     nth_best_tile.mag_min = mag_range[0]
                     nth_best_tile.mag_max = mag_range[1] 
                     
                     tile_list.append(nth_best_tile) 
-                
-            # Recalculate the ranking list
-            #ranking_list = [self.calculate_tile_score(tile) for tile in candidate_tiles]
 
             # Logging
             logging.info('%d targets, %d standards, %d guides' %
@@ -1773,55 +1915,65 @@ class FWTiler(object):
                           tile_list[-1].count_assigned_targets_guide(), ))
             logging.info('Now assigned %d tiles' % (len(tile_list), ))
             logging.info('Priority completeness achieved: {0:1.4f}'.format(
-                            (float(n_priority_targets - remaining_priority_targets) \
+                            (float(n_priority_targets - remaining_pri_tgts) \
                             / float(n_priority_targets))) )
             logging.info('Remaining priority targets: {0:d} / {1:d}'.format(
-                         remaining_priority_targets, n_priority_targets))
-            logging.info('Remaining guides & standards (this mag range): %d, %d' %
-                         (len(guide_targets_range), len(standard_targets_range)))
+                         remaining_pri_tgts, n_priority_targets))
+            logging.info('Remaining guides & standards (this mag range): '
+                         "%d, %d" % (len(guide_targets_range), 
+                                     len(standard_targets_range)))
         
             # Two checks to be run here:
             # 1 - Reduce the selection of non-priority targets by setting
-            #     disqualify_below_min to False if the max of the ranking list falls below
-            #     some threshold (e.g. the score of a single priority target). This moves
-            #     the tiling more rapidly towards completion and allows priority targets
-            #     not in the priority magnitude range to observed in the next mag bin.
-            # 2 - If there are no more legal targets (because of disqualify_below_min 
-            #     setting the score to zero when below the minimum number of standards/
-            #     guides) cease disqualifying such tiles to head towards completion.
-            # Note: by having the two booleans first we can short-circuit the expression
-            # in the event they are false, removing the need to sort the ranking list.
-            # This structure ensures we only enter either of the two if statements only
-            # once, as we flip the booleans after successful use.
-            if self.enforce_min_tile_score and max(ranking_list.values()) < self.min_tile_score:
-                logging.info('Detected no tiles above min score - relaxing requirements')
+            #     disqualify_below_min to False if the max of the ranking list
+            #     falls below
+            #     some threshold (e.g. the score of a single priority target). 
+            #     This moves the tiling more rapidly towards completion and
+            #     allows priority targets not in the priority magnitude range 
+            #     to observed in the next mag bin.
+            # 2 - If there are no more legal targets (because of 
+            #     disqualify_below_min setting the score to zero when below the
+            #     minimum number of standards/guides) cease disqualifying such
+            #     tiles to head towards completion.
+            # Note: by having the two booleans first we can short-circuit the
+            # expression in the event they are false, removing the need to sort
+            # the ranking list. This structure ensures we only enter either of
+            # the two if statements only once, as we flip the booleans after 
+            # successful use.
+            if (self.enforce_min_tile_score 
+                and max(ranking_list.values()) < self.min_tile_score):
+                logging.info('No tiles above min score, relaxing requirements')
                 self.enforce_min_tile_score = False
                 self.disqualify_below_min = False
-                ranking_list = self.compute_ranking_dictionary(candidate_tiles)     
+                ranking_list = self.compute_ranking_dictionary(candidate_tiles)
                                 
-            elif self.disqualify_below_min and max(ranking_list.values()) < 0.05:
-                logging.info('Detected no remaining legal tiles - relaxing requirements')
+            elif (self.disqualify_below_min 
+                and max(ranking_list.values()) < 0.05):
+                logging.info('No remaining legal tiles, relaxing requirements')
                 self.disqualify_below_min = False
-                ranking_list = self.compute_ranking_dictionary(candidate_tiles)           
+                ranking_list = self.compute_ranking_dictionary(candidate_tiles)
         
         # Print summary of the magnitude range
-        cc = (float(n_priority_targets - remaining_priority_targets)
+        cc = (float(n_priority_targets - remaining_pri_tgts)
                           / float(n_priority_targets))
-        print "Mag range complete with %i tiles, %5.2f %% complete," % (len(tile_list),
-                                                                        100*cc),
+
+        print "Mag range complete with %i tiles," % len(tile_list),
+        print "%5.2f %% complete," % (100*cc),
         if cc < self.completeness_target:
-            logging.warning("### WARNING: mag range tiling aborted prior to completeness")
+            logging.warning("### WARNING: mag range tiling aborted prior to " 
+                            "completeness")
             
         # Reset booleans
-        self.disqualify_below_min = self.disqualify_below_min_original                                                             
+        self.disqualify_below_min = self.disqualify_below_min_original
         self.enforce_min_tile_score = self.enforce_min_tile_score_original  
                                                                           
         return tile_list
 
     
     #@profile
-    def greedy_tile_mag_range(self, candidate_targets, standard_targets, guide_targets, 
-                              sky_targets, candidate_tiles, range_ix):
+    def greedy_tile_mag_range(self, candidate_targets, standard_targets, 
+                              guide_targets, sky_targets, candidate_tiles, 
+                              range_ix):
         """Function to perform a greedy sky tiling for a given magnitude range.
     
         Parameters
@@ -1839,7 +1991,8 @@ class FWTiler(object):
             The entire list of sky targets to consider. 
     
         candidate_tiles: list of :class: `TaipanTile`
-            The list of filled candidate tiles covering the section of sky observed.
+            The list of filled candidate tiles covering the section of sky
+            observed.
             
         range_ix: int
             The index of the magnitude range to tile.
@@ -1847,8 +2000,8 @@ class FWTiler(object):
         Returns
         -------
         tile_list: list of :class: `TaipanTile`
-            The set of tiles meeting the completeness requirement for the provided set of
-            targets.
+            The set of tiles meeting the completeness requirement for the 
+            provided set of targets.
         """
         # Initialise the tile list for this magnitude range
         tile_list = []
@@ -1857,8 +2010,8 @@ class FWTiler(object):
         
         self.completeness_target = self.completeness_targets[range_ix]
     
-        print "Tiling mag range %s to %0.2f%% completion" % (mag_range, 
-                                                          self.completeness_target)
+        print "Tiling mag range %s" % mag_range,
+        print "%0.2f%% completion" % self.completeness_target
         
         # Perform check to see if using priority magnitude ranges
         try:
@@ -1869,17 +2022,20 @@ class FWTiler(object):
         # Check to see if this is the final magnitude range to be considered
         last_range = not (range_ix < (len(self.mag_ranges) - 1))  
     
-        # Determine targets, standards, and guides                                                 
-        candidate_targets_range = self.get_targets_mag_range(candidate_targets, mag_range, 
-                                                             mag_range_prioritise, 
-                                                             last_range)  
+        # Determine targets, standards, and guides
+        candidate_targets_range = self.get_targets_mag_range(candidate_targets, 
+                                                        mag_range, 
+                                                        mag_range_prioritise, 
+                                                        last_range)  
         
-        standard_targets_range = self.get_standards_mag_range(standard_targets, mag_range)
+        standard_targets_range = self.get_standards_mag_range(standard_targets, 
+                                                              mag_range)
         
         non_candidate_guide_targets = self.get_guides_mag_range(guide_targets, 
-                                                                candidate_targets_range)
+                                                       candidate_targets_range)
     
-        logging.info("Mag range: {0:5.1f} {1:5.1f}".format(mag_range[0], mag_range[1]))
+        logging.info("Mag range: {0:5.1f} {1:5.1f}".format(mag_range[0], 
+                                                           mag_range[1]))
         logging.info("Mag range to prioritize: {0:5.1f} {1:5.1f}".format(
                  mag_range_prioritise[0],mag_range_prioritise[1]))
         logging.info("Number of targets in this range: {0:d}".format(
@@ -1887,9 +2043,11 @@ class FWTiler(object):
         
         # Generate tiling for the magnitude range
         start = time.time()
-        tile_list = self.greedy_tile_sky(candidate_targets, candidate_targets_range, 
+        tile_list = self.greedy_tile_sky(candidate_targets, 
+                                         candidate_targets_range, 
                                          standard_targets_range, 
-                                         non_candidate_guide_targets, sky_targets,
+                                         non_candidate_guide_targets, 
+                                         sky_targets,
                                          candidate_tiles, mag_range)
         delta = time.time() - start
         print "done in %d:%02.1f" % (delta/60, delta % 60.)
@@ -1903,38 +2061,40 @@ class FWTiler(object):
         start = time.time()
         tile_list = tl.tiling_consolidate(tile_list)
         delta = time.time() - start
-        print ("--> %i tiles, done in %d:%02.1f \n") % (len(tile_list), delta/60, 
-                                                        delta % 60.)
+        print ("--> %i tiles, done in %d:%02.1f \n") % (len(tile_list), 
+                                                        delta/60, delta % 60.)
       
-        logging.info('Mag range: {0:3.1f} to {1:3.1f}, '.format(mag_range_prioritise[0], 
-                    mag_range_prioritise[1]))
+        logging.info('Mag range: {0:3.1f} to {1:3.1f}, '.format(
+                    mag_range_prioritise[0], mag_range_prioritise[1]))
         logging.info('Total Tiles so far = {0:d}'.format(len(tile_list))) 
     
         return tile_list
     
     
     #@profile
-    def generate_tiling(self, candidate_targets, standard_targets, guide_targets, 
-                        sky_targets):
+    def generate_tiling(self, candidate_targets, standard_targets, 
+                        guide_targets, sky_targets):
         """
-        Generate a tiling based on the greedy algorithm operating on a set of magnitude 
-        ranges sequentially. Within each magnitude range, a complete set of tiles are 
-        selected that enables completeness higher than the minimum priority only.
+        Generate a tiling based on the greedy algorithm operating on a set of 
+        magnitude ranges sequentially. Within each magnitude range, a complete 
+        set of tiles are selected that enables completeness higher than the 
+        minimum priority only.
 
         For each magnitude range, the greedy algorithm works as follows:
     
         - Generate a set of tiles covering the area of interest.
-        - Unpick each tile (meaning allocate fibers), allowing targets to be duplicated '
-          between tiles.
+        - Unpick each tile (meaning allocate fibers), allowing targets to be 
+          duplicated between tiles.
         - Select the 'best' tile from this set, and add it to the resultant
           tiling.
-        - Replace the removed tile in the list (i.e. as you probably haven't yet observed
-          all targets in that part of the sky), then re-unpick the tiles in the set which 
-          are affected by the removal of the tile - i.e. the tile just replaced and 
-          neighbouring tiles.
+        - Replace the removed tile in the list (i.e. as you probably haven't 
+          yet observed all targets in that part of the sky), then re-unpick the
+          tiles in the set which are affected by the removal of the tile - i.e.
+          the tile just replaced and neighbouring tiles.
         - Repeat until no useful tiles remain, or the completeness target is
           reached.
-        - Then go on to the next magnitude range until there are no magnitude ranges left.
+        - Then go on to the next magnitude range until there are no magnitude 
+          ranges left.
 
         Parameters
         ----------
@@ -1953,15 +2113,15 @@ class FWTiler(object):
         Returns
         -------
         tile_list: list of :class: `TaipanTile`
-            The set of tiles meeting the completeness requirement for the provided set of
-            targets.
+            The set of tiles meeting the completeness requirement for the 
+            provided set of targets.
         
         final_completeness: float
             The target completeness achieved.
         
         candidate_targets: list of :class:`TaipanTarget`
-            Any targets from candidate_targets that do not appear in the final tiling_list 
-            (i.e. were not assigned to a successful tile).
+            Any targets from candidate_targets that do not appear in the final 
+            tiling_list (i.e. were not assigned to a successful tile).
         """
         # Initialise list to hold all tiling results
         tile_lists = []
@@ -1980,11 +2140,12 @@ class FWTiler(object):
         no_submitted_targets = len(candidate_targets)
         
         if no_submitted_targets == 0:
-            raise ValueError('Attempting to generate a tiling with no targets!')
+            raise ValueError('Attempting to generate tiling with no targets!')
                 
         # Generate a greedy style tiling for each magnitude range 
         for range_ix in xrange(len(self.mag_ranges)):
-            tile_list =  self.greedy_tile_mag_range(candidate_targets, standard_targets, 
+            tile_list =  self.greedy_tile_mag_range(candidate_targets, 
+                                                    standard_targets, 
                                                     guide_targets, sky_targets, 
                                                     candidate_tiles, range_ix)
             tile_lists.append(tile_list)
@@ -2015,24 +2176,25 @@ class FWTiler(object):
         return tile_list, final_completeness, candidate_targets 
 
 
-# ----------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # External tiling code for multiprocessing
-# ----------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 #@profile
 def repick_within_radius(best_tile, candidate_tiles, candidate_targets, 
                          candidate_standards, candidate_guides, candidate_sky, 
                          unpick_settings, n_radii=2):
-    """Function to repick neighbouring tiles after selecting a tile for the final 
-    tiling to account for target duplication between tiles.
+    """Function to repick neighbouring tiles after selecting a tile for the 
+    final tiling to account for target duplication between tiles.
 
     Parameters
     ----------
     best_tile: TaipanTile
-        The best (highest-ranked distant) tile selected as part of the greedy tiling 
-        algorithm.
+        The best (highest-ranked distant) tile selected as part of the greedy 
+        tiling algorithm.
     
     candidate_tiles: list of :class: `TaipanTile`
-        The list of *nearby* filled candidate tiles covering the section of sky observed.   
+        The list of *nearby* filled candidate tiles covering the section of sky
+        observed.   
          
     candidate_targets: list of :class:`TaipanTarget`
         The list of *nearby* candidate targets to consider for repicking.
@@ -2047,15 +2209,16 @@ def repick_within_radius(best_tile, candidate_tiles, candidate_targets,
         The list of *nearby* sky targets to consider for repicking.
         
     unpick_settings: Dict
-        Dictionary to store the tile unpick settings of the FWTiler object when passing to
-        this function. The multiprocessing environment that this function is used in 
-        prevents the use of instance methods, and the dictionary is a convenient wrapper
-        to avoid the unnecessary exposure of parameters. Consists of:
+        Dictionary to store the tile unpick settings of the FWTiler object when
+        passing to this function. The multiprocessing environment that this 
+        function is used in prevents the use of instance methods, and the 
+        dictionary is a convenient wrapper to avoid the unnecessary exposure of
+        parameters. Consists of:
         
             overwrite_existing, check_tile_radius, recompute_difficulty, 
-            tile_unpick_method, combined_weight, sequential_ordering,rank_supplements,
-            repick_after_complete, consider_removed_targets, allow_standard_targets, and
-            assign_sky_first, assign_sky_fibres
+            tile_unpick_method, combined_weight, sequential_ordering,
+            rank_supplements, repick_after_complete, consider_removed_targets,
+            allow_standard_targets, assign_sky_first, assign_sky_fibres
     
     n_radii: int
         The radius out to which neighbouring tiles should be repicked.
@@ -2063,50 +2226,62 @@ def repick_within_radius(best_tile, candidate_tiles, candidate_targets,
     Returns
     -------
     candidate_tiles: list of :class: `TaipanTile`
-        The now re-unpicked list of *nearby* filled candidate tiles covering the section 
-        of sky observed, with duplicates removed from the recently selected best tile.
+        The now re-unpicked list of *nearby* filled candidate tiles covering 
+        the section of sky observed, with duplicates removed from the recently
+        selected best tile.
     """
     # Repick any tiles within n_radii*TILE_RADIUS
     assigned_targets = best_tile.get_assigned_targets_science()
 
     nearby_candidate_tiles = tp.targets_in_range(best_tile.ra, best_tile.dec, 
-                                            candidate_tiles, n_radii*tp.TILE_RADIUS) 
+                                            candidate_tiles, 
+                                            n_radii*tp.TILE_RADIUS) 
 
     affected_tiles = list({atile for atile in nearby_candidate_tiles 
                           for t in assigned_targets \
                           if t in atile.get_assigned_targets_science()})
                           
-    # Tile order is scrambled for MC runs, so rather than adding the empty replacement 
-    # tile by [-1] index as works for the n_cores=0 case, explicitly add any tiles that 
-    # have no allocated fibres 
+    # Tile order is scrambled for MC runs, so rather than adding the empty
+    # replacement tile by [-1] index as works for the n_cores=0 case, 
+    # explicitly add any tiles that have no allocated fibres 
     for tile in candidate_tiles:
         if tile.count_assigned_fibres() == 0:
             affected_tiles.append(tile)
     
-    # Pre-generate the KD tree for the nearby target, standard and guide lists. These will
-    # remain the same, with consistent ordering, per given neighbourhood
+    # Pre-generate the KD tree for the nearby target, standard and guide lists.
+    # These will remain the same, with consistent ordering, per given 
+    # neighbourhood
     target_tree = precompute_kd_tree(candidate_targets)
     standard_tree = precompute_kd_tree(candidate_standards)
     guide_tree = precompute_kd_tree(candidate_guides)
     sky_tree = precompute_kd_tree(candidate_sky)
     
     for tile_i, tile in enumerate(affected_tiles):
-        # Repick the affected tiles, but making sure to only supply the targets that 
-        # actually fall within the tile boundaries - unnecessary processing otherwise
-        tile.unpick_tile(tp.targets_in_range(tile.ra, tile.dec, candidate_targets, 
-                                             1*tp.TILE_RADIUS, tree=target_tree), 
-                         tp.targets_in_range(tile.ra, tile.dec, candidate_standards, 
-                                            1*tp.TILE_RADIUS, tree=standard_tree), 
-                         tp.targets_in_range(tile.ra, tile.dec, candidate_guides, 
-                                            1*tp.TILE_RADIUS, tree=guide_tree),
-                         tp.targets_in_range(tile.ra, tile.dec, candidate_sky, 
-                                            1*tp.TILE_RADIUS, tree=sky_tree),                                            
+        # Repick the affected tiles, but making sure to only supply the targets
+        # that actually fall within the tile boundaries - unnecessary 
+        # processing otherwise
+        tile.unpick_tile(tp.targets_in_range(tile.ra, tile.dec, 
+                                             candidate_targets, 
+                                             1*tp.TILE_RADIUS, 
+                                             tree=target_tree), 
+                         tp.targets_in_range(tile.ra, tile.dec, 
+                                             candidate_standards, 
+                                             1*tp.TILE_RADIUS, 
+                                             tree=standard_tree), 
+                         tp.targets_in_range(tile.ra, tile.dec, 
+                                             candidate_guides, 
+                                             1*tp.TILE_RADIUS, 
+                                             tree=guide_tree),
+                         tp.targets_in_range(tile.ra, tile.dec, 
+                                             candidate_sky, 
+                                             1*tp.TILE_RADIUS, tree=sky_tree),
                          **unpick_settings)
 
-    # It is possible for a candidate tile to have no assigned fibres at this point, but
-    # that should occur only towards the end of a tiling run, or for a sparsely populated
-    # field (i.e. the bright magnitude bin). So long as the replacement tiles are properly
-    # unpicked, there should be no issue reaching the completion target.
+    # It is possible for a candidate tile to have no assigned fibres at this 
+    # point, but that should occur only towards the end of a tiling run, or for
+    # a sparsely populated field (i.e. the bright magnitude bin). So long as 
+    # the replacement tiles are properly unpicked, there should be no issue 
+    # reaching the completion target.
     
     return candidate_tiles
 
@@ -2118,10 +2293,10 @@ def repick_within_radius_pool(input_params):
     input_params is tuple of form: 
     (process_i, neighbourhood_tiles, repicked_tiles, fwtiler.unpick_settings)
     
-    Where process_i is used to index neighbourhood_tiles, which is of type manager.list()
-    and holds the targets, standards, guides, and tiles from the neighbourhood. 
-    repicked_tiles is also of type manager.list(), and is used to store the repicked 
-    tiles from the neighbourhood.
+    Where process_i is used to index neighbourhood_tiles, which is of type 
+    manager.list() and holds the targets, standards, guides, and tiles from the
+    neighbourhood. repicked_tiles is also of type manager.list(), and is used 
+    to store the repicked tiles from the neighbourhood.
     
     Parameters
     ----------
@@ -2147,51 +2322,61 @@ def repick_within_radius_pool(input_params):
     assigned_targets = best_tile.get_assigned_targets_science()
 
     nearby_candidate_tiles = tp.targets_in_range(best_tile.ra, best_tile.dec, 
-                                            candidate_tiles, n_radii*tp.TILE_RADIUS) 
+                                            candidate_tiles, 
+                                            n_radii*tp.TILE_RADIUS) 
 
     affected_tiles = list({atile for atile in nearby_candidate_tiles 
                           for t in assigned_targets \
                           if t in atile.get_assigned_targets_science()})
                       
-    # Tile order is scrambled for MC runs, so rather than adding the empty replacement 
-    # tile by [-1] index as works for the n_cores=0 case, explicitly add any tiles that 
-    # have no allocated fibres 
+    # Tile order is scrambled for MC runs, so rather than adding the empty 
+    # replacement tile by [-1] index as works for the n_cores=0 case, 
+    # explicitly add any tiles that have no allocated fibres 
     for tile in candidate_tiles:
         if tile.count_assigned_fibres() == 0:
             affected_tiles.append(tile)
 
-    # Pre-generate the KD tree for the nearby target, standard and guide lists. These will
-    # remain the same, with consistent ordering, per given neighbourhood
+    # Pre-generate the KD tree for the nearby target, standard and guide lists.
+    # These will remain the same, with consistent ordering, per given 
+    # neighbourhood
     target_tree = precompute_kd_tree(candidate_targets)
     standard_tree = precompute_kd_tree(candidate_standards)
     guide_tree = precompute_kd_tree(candidate_guides)
 
     for tile_i, tile in enumerate(affected_tiles):
-        # Repick the affected tiles, but making sure to only supply the targets that 
-        # actually fall within the tile boundaries - unnecessary processing otherwise
-        tile.unpick_tile(tp.targets_in_range(tile.ra, tile.dec, candidate_targets, 
-                                             1*tp.TILE_RADIUS, tree=target_tree), 
-                         tp.targets_in_range(tile.ra, tile.dec, candidate_standards, 
-                                            1*tp.TILE_RADIUS, tree=standard_tree), 
-                         tp.targets_in_range(tile.ra, tile.dec, candidate_guides, 
-                                            1*tp.TILE_RADIUS, tree=guide_tree),
+        # Repick the affected tiles, but making sure to only supply the targets
+        # that actually fall within the tile boundaries - unnecessary 
+        # processing otherwise
+        tile.unpick_tile(tp.targets_in_range(tile.ra, tile.dec, 
+                                             candidate_targets, 
+                                             1*tp.TILE_RADIUS, 
+                                             tree=target_tree), 
+                         tp.targets_in_range(tile.ra, tile.dec, 
+                                             candidate_standards, 
+                                             1*tp.TILE_RADIUS, 
+                                             tree=standard_tree), 
+                         tp.targets_in_range(tile.ra, tile.dec, 
+                                             candidate_guides, 
+                                             1*tp.TILE_RADIUS, 
+                                             tree=guide_tree),
                          **unpick_settings)
 
-    # It is possible for a candidate tile to have no assigned fibres at this point, but
-    # that should occur only towards the end of a tiling run, or for a sparsely populated
-    # field (i.e. the bright magnitude bin). So long as the replacement tiles are properly
-    # unpicked, there should be no issue reaching the completion target.
+    # It is possible for a candidate tile to have no assigned fibres at this 
+    # point, but that should occur only towards the end of a tiling run, or for
+    # a sparsely populated field (i.e. the bright magnitude bin). So long as 
+    # the replacement tiles are properly unpicked, there should be no issue 
+    # reaching the completion target.
     
     # Add the now repicked tiles to the "results" manager to finish
     repicked_tiles.append(candidate_tiles)
 
 
-# ----------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # Helper functions
-# ----------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 def is_same_taipan_object(obj_1, obj_2):
-    """Function to check the equivalence of two TaipanPoint derived objects. Stand-in for
-    the currently not implemented object level equivalence tests.
+    """Function to check the equivalence of two TaipanPoint derived objects. 
+    Stand-in for the currently not implemented object level equivalence tests.
     
     Parameters
     ----------
@@ -2208,20 +2393,22 @@ def is_same_taipan_object(obj_1, obj_2):
     equivalent = False
     
     if type(obj_1) == type(obj_2):
-        # For TaipanTargets to be considered the same, they must have the same ID, RA, 
-        # DEC, and science/standard/guide status
-        if (type(obj_1) is tp.TaipanTarget) and (obj_1.idn == obj_2.idn) and \
-            (obj_1.science == obj_2.science) and (obj_1.standard == obj_2.standard) and \
-            (obj_1.guide == obj_2.guide):
+        # For TaipanTargets to be considered the same, they must have the same 
+        # ID, RA,  DEC, and science/standard/guide status
+        if ((type(obj_1) is tp.TaipanTarget) and (obj_1.idn == obj_2.idn) 
+            and (obj_1.science == obj_2.science) 
+            and (obj_1.standard == obj_2.standard)
+            and (obj_1.guide == obj_2.guide)):
             equivalent = True
 
     return equivalent
 
 
 def count_unique_science_targets(tiling):
-    """Function to run at the conclusion of the tiling run to detect any duplication in 
-    the assigned targets (duplication likely caused by unintended consequences of running
-    tiling in parallel. This function does not consider reused standards duplicates.
+    """Function to run at the conclusion of the tiling run to detect any 
+    duplication in the assigned targets (duplication likely caused by 
+    unintended consequences of running tiling in parallel. This function does 
+    not consider reused standards duplicates.
     
     Parameters
     ----------
@@ -2235,7 +2422,7 @@ def count_unique_science_targets(tiling):
     total: int
         The total number of targets observed within the tile set.
     duplicates: int
-        The total number of *duplicate* targets observed within the tile set.                
+        The total number of *duplicate* targets observed within the tile set.
     """
     uniques = 0
     duplicates = 0
@@ -2244,8 +2431,9 @@ def count_unique_science_targets(tiling):
     
     # Look for duplicates by assuming RA and DEC will be unique
     for tile in tiling:
-        for target in tile.get_assigned_targets_science(include_science_standards=False):
-            all_targets.append(str(target.ra) + "-" + str(target.dec))           
+        for target in tile.get_assigned_targets_science(
+            include_science_standards=False):
+            all_targets.append(str(target.ra) + "-" + str(target.dec))
     
     # Using a set in this fashion is quicker than a for loop
     unique = len(set(all_targets))
@@ -2256,8 +2444,8 @@ def count_unique_science_targets(tiling):
 
     
 def precompute_kd_tree(target_list):
-    """Precomputes the KD tree for a list of targets. Returns None if a brute force would
-    be more efficient than computing the KD tree.
+    """Precomputes the KD tree for a list of targets. Returns None if a brute 
+    force would be more efficient than computing the KD tree.
     
     Parameters
     ----------

--- a/taipan/fwtiling.py
+++ b/taipan/fwtiling.py
@@ -2404,7 +2404,7 @@ def is_same_taipan_object(obj_1, obj_2):
     return equivalent
 
 
-def count_unique_science_targets(tiling):
+def count_unique_science_targets(tiling, include_science_standards=False):
     """Function to run at the conclusion of the tiling run to detect any 
     duplication in the assigned targets (duplication likely caused by 
     unintended consequences of running tiling in parallel. This function does 
@@ -2414,6 +2414,8 @@ def count_unique_science_targets(tiling):
     ----------
     tiling: list of TaipanTile objects
         A list of TaipanTiles (e.g. the results of a tiling run)
+    include_science_standards: boolean
+        Whether to include science standards in the count. Defaults to False.
         
     Returns
     -------
@@ -2432,7 +2434,7 @@ def count_unique_science_targets(tiling):
     # Look for duplicates by assuming RA and DEC will be unique
     for tile in tiling:
         for target in tile.get_assigned_targets_science(
-            include_science_standards=False):
+            include_science_standards=include_science_standards):
             all_targets.append(str(target.ra) + "-" + str(target.dec))
     
     # Using a set in this fashion is quicker than a for loop

--- a/taipan/tiling.py
+++ b/taipan/tiling.py
@@ -244,8 +244,9 @@ def generate_SH_tiling(tiling_file, randomise_seed=True, randomise_pa=False):
         # print tile_cents[0]
     # print len(tile_cents)
     else:
-        # % 360 needed in default case to prevent RA values of 360, which raise exceptions
-        # in the TaipanTile constructor/RA setter when not employing random_seed=True 
+        # % 360 needed in default case to prevent RA values of 360, which 
+        # raise exceptions in the TaipanTile constructor/RA setter when not 
+        # employing random_seed=True 
         tile_cents = [((c[0] + 180.) % 360. - 180., c[1]) for c in tile_cents] 
 
     tile_list = [tp.TaipanTile(c[0] + 180., c[1], pa=gen_pa(randomise_pa))


### PR DESCRIPTION
Changes:
- Sky fibres are now correctly assigned by assign_sky_fibres - fixed a bug where we required fibres marked "sky" to assign targets to, but had previously cleared all; such values back to None. Does not assign above SKY_PER_TILE_MIN in all cases, but this happens *very* infrequently and can be dealt with by the changes to disqualify_below_min in the tile scoring function to not consider such tiles. Remains a TODO to find the cause, but suspect the guide algorithm also has similar issues.
- FW code was formatted to 90 character length lines, now to 79 characters to meet PEP8 standard
- FW plotting code now plots histograms for sky fibres